### PR TITLE
refactor!: use int64 for all IDs

### DIFF
--- a/account_groups.go
+++ b/account_groups.go
@@ -8,7 +8,7 @@ type AccountGroups []AccountGroup
 // AccountGroup - An account within a ThousandEyes organization
 type AccountGroup struct {
 	AccountGroupName *string `json:"accountGroupName,omitempty"`
-	AID              *int    `json:"aid,omitempty"`
+	AID              *int64  `json:"aid,omitempty"`
 }
 
 // SharedWithAccount describes accounts with which a resource is shared.
@@ -16,7 +16,7 @@ type AccountGroup struct {
 // in JSON object names.
 type SharedWithAccount struct {
 	AccountGroupName *string `json:"name,omitempty"`
-	AID              *int    `json:"aid,omitempty"`
+	AID              *int64  `json:"aid,omitempty"`
 }
 
 // GetAccountGroups - Get third party and webhook integrations

--- a/account_groups_test.go
+++ b/account_groups_test.go
@@ -21,7 +21,7 @@ func TestClient_GetAccountGroups(t *testing.T) {
 	expected := []SharedWithAccount{
 		{
 			AccountGroupName: String("Test Account"),
-			AID:              Int(1),
+			AID:              Int64(1),
 		},
 	}
 

--- a/agent.go
+++ b/agent.go
@@ -10,7 +10,7 @@ type Agents []Agent
 
 // Agent - Agent struct
 type Agent struct {
-	AgentID               *int                 `json:"agentId,omitempty"`
+	AgentID               *int64               `json:"agentId,omitempty"`
 	AgentName             *string              `json:"agentName,omitempty"`
 	AgentType             *string              `json:"agentType,omitempty"`
 	CountryID             *string              `json:"countryId,omitempty"`
@@ -35,7 +35,7 @@ type Agent struct {
 
 //ClusterMember - ClusterMember struct
 type ClusterMember struct {
-	MemberID          *int      `json:"memberId,omitempty"`
+	MemberID          *int64    `json:"memberId,omitempty"`
 	Name              *string   `json:"name,omitempty"`
 	IPAddresses       *[]string `json:"IPAddresses,omitempty"`
 	PublicIPAddresses *[]string `json:"PublicIPAddresses,omitempty"`

--- a/agent_agent.go
+++ b/agent_agent.go
@@ -31,7 +31,7 @@ type AgentAgent struct {
 	BGPMonitors            *[]BGPMonitor `json:"bgpMonitors,omitempty"`
 	Direction              *string       `json:"direction,omitempty"`
 	DSCP                   *string       `json:"dscp,omitempty"`
-	DSCPID                 *int          `json:"dscpId"`
+	DSCPID                 *int64        `json:"dscpId"`
 	Interval               *int          `json:"interval,omitempty"`
 	MSS                    *int          `json:"mss,omitempty"`
 	NetworkMeasurements    *bool         `json:"networkMeasurements,omitempty" te:"int-bool"`
@@ -40,7 +40,7 @@ type AgentAgent struct {
 	PathTraceMode          *string       `json:"pathTraceMode,omitempty"`
 	Port                   *int          `json:"port,omitempty"`
 	Protocol               *string       `json:"protocol,omitempty"`
-	TargetAgentID          *int          `json:"targetAgentId,omitempty"`
+	TargetAgentID          *int64        `json:"targetAgentId,omitempty"`
 	ThroughputDuration     *int          `json:"throughputDuration,omitempty"`
 	ThroughputMeasurements *bool         `json:"throughputMeasurements,omitempty" te:"int-bool"`
 	ThroughputRate         *int          `json:"throughputRate,omitempty"`
@@ -77,14 +77,14 @@ func (t *AgentAgent) UnmarshalJSON(data []byte) error {
 }
 
 // AddAgent - Adds an agent to agent test
-func (t *AgentAgent) AddAgent(id int) {
-	agent := Agent{AgentID: Int(id)}
+func (t *AgentAgent) AddAgent(id int64) {
+	agent := Agent{AgentID: Int64(id)}
 	*t.Agents = append(*t.Agents, agent)
 }
 
 // AddAlertRule - Adds an alert to agent test
-func (t *AgentAgent) AddAlertRule(id int) {
-	alertRule := AlertRule{RuleID: Int(id)}
+func (t *AgentAgent) AddAlertRule(id int64) {
+	alertRule := AlertRule{RuleID: Int64(id)}
 	*t.AlertRules = append(*t.AlertRules, alertRule)
 }
 

--- a/agent_agent_test.go
+++ b/agent_agent_test.go
@@ -9,14 +9,14 @@ import (
 
 func TestClient_AddAgentAgentAlertRule(t *testing.T) {
 	test := AgentAgent{TestName: String("test"), AlertRules: &[]AlertRule{}}
-	expected := AgentAgent{TestName: String("test"), AlertRules: &[]AlertRule{{RuleID: Int(1)}}}
+	expected := AgentAgent{TestName: String("test"), AlertRules: &[]AlertRule{{RuleID: Int64(1)}}}
 	test.AddAlertRule(1)
 	assert.Equal(t, expected, test)
 }
 
 func TestClient_AgentAgentAddAgent(t *testing.T) {
 	test := AgentAgent{TestName: String("test"), Agents: &[]Agent{}}
-	expected := AgentAgent{TestName: String("test"), Agents: &[]Agent{{AgentID: Int(1)}}}
+	expected := AgentAgent{TestName: String("test"), Agents: &[]Agent{{AgentID: Int64(1)}}}
 	test.AddAgent(1)
 	assert.Equal(t, expected, test)
 }
@@ -67,7 +67,7 @@ func TestClient_GetAgentAgentJsonError(t *testing.T) {
 
 func TestClient_AddAlertRule(t *testing.T) {
 	test := AgentAgent{TestName: String("test"), AlertRules: &[]AlertRule{}}
-	expected := AgentAgent{TestName: String("test"), AlertRules: &[]AlertRule{{RuleID: Int(1)}}}
+	expected := AgentAgent{TestName: String("test"), AlertRules: &[]AlertRule{{RuleID: Int64(1)}}}
 	test.AddAlertRule(1)
 	assert.Equal(t, expected, test)
 }

--- a/agent_server.go
+++ b/agent_server.go
@@ -94,14 +94,14 @@ func extractPort(test AgentServer) (AgentServer, error) {
 }
 
 // AddAgent - Add agent to server test
-func (t *AgentServer) AddAgent(id int) {
-	agent := Agent{AgentID: Int(id)}
+func (t *AgentServer) AddAgent(id int64) {
+	agent := Agent{AgentID: Int64(id)}
 	*t.Agents = append(*t.Agents, agent)
 }
 
 // AddAlertRule - Adds an alert to agent test
-func (t *AgentServer) AddAlertRule(id int) {
-	alertRule := AlertRule{RuleID: Int(id)}
+func (t *AgentServer) AddAlertRule(id int64) {
+	alertRule := AlertRule{RuleID: Int64(id)}
 	*t.AlertRules = append(*t.AlertRules, alertRule)
 }
 

--- a/agent_server_test.go
+++ b/agent_server_test.go
@@ -9,14 +9,14 @@ import (
 
 func TestClient_AddAgentSeverAlertRule(t *testing.T) {
 	test := AgentServer{TestName: String("test"), AlertRules: &[]AlertRule{}}
-	expected := AgentServer{TestName: String("test"), AlertRules: &[]AlertRule{{RuleID: Int(1)}}}
+	expected := AgentServer{TestName: String("test"), AlertRules: &[]AlertRule{{RuleID: Int64(1)}}}
 	test.AddAlertRule(1)
 	assert.Equal(t, expected, test)
 }
 
 func TestClient_AgentServerAddAgent(t *testing.T) {
 	test := AgentServer{TestName: String("test"), Agents: &[]Agent{}}
-	expected := AgentServer{TestName: String("test"), Agents: &[]Agent{{AgentID: Int(1)}}}
+	expected := AgentServer{TestName: String("test"), Agents: &[]Agent{{AgentID: Int64(1)}}}
 	test.AddAgent(1)
 	assert.Equal(t, expected, test)
 }
@@ -52,7 +52,7 @@ func TestClient_CreateAgentServer(t *testing.T) {
 
 func TestClient_AddAgentServerAlertRule(t *testing.T) {
 	test := AgentServer{TestName: String("test"), AlertRules: &[]AlertRule{}}
-	expected := AgentServer{TestName: String("test"), AlertRules: &[]AlertRule{{RuleID: Int(1)}}}
+	expected := AgentServer{TestName: String("test"), AlertRules: &[]AlertRule{{RuleID: Int64(1)}}}
 	test.AddAlertRule(1)
 	assert.Equal(t, expected, test)
 }
@@ -207,7 +207,7 @@ func TestExtractPort(t *testing.T) {
 	test := AgentServer{
 		Agents: &[]Agent{
 			{
-				AgentID: Int(75),
+				AgentID: Int64(75),
 			},
 		},
 		Interval: Int(3600),

--- a/agent_test.go
+++ b/agent_test.go
@@ -19,11 +19,11 @@ func TestClient_GetAgents(t *testing.T) {
 	// Define expected values from the API (based on the JSON we print out above)
 	expected := Agents{
 		Agent{
-			AgentID: Int(1),
+			AgentID: Int64(1),
 			Enabled: Bool(true),
 		},
 		Agent{
-			AgentID: Int(2),
+			AgentID: Int64(2),
 			Enabled: Bool(false),
 		},
 	}
@@ -41,7 +41,7 @@ func TestClient_GetAgent(t *testing.T) {
 		assert.Equal(t, "GET", r.Method)
 		_, _ = w.Write([]byte(out))
 	})
-	expected := Agent{AgentID: Int(1), Enabled: Bool(true)}
+	expected := Agent{AgentID: Int64(1), Enabled: Bool(true)}
 	res, err := client.GetAgent(1)
 	teardown()
 	assert.Nil(t, err)
@@ -184,11 +184,11 @@ func TestClient_RemoveAgentFromCluster(t *testing.T) {
 	res, _ := client.RemoveAgentsFromCluster(1, []int{8001})
 	exp := []Agent{
 		{
-			AgentID:   Int(1),
+			AgentID:   Int64(1),
 			AgentName: String("test"),
 			ClusterMembers: &[]ClusterMember{
 				{
-					MemberID: Int(80002),
+					MemberID: Int64(80002),
 					Name:     String("test"),
 				},
 			},
@@ -208,11 +208,11 @@ func TestClient_AddAgentToCluster(t *testing.T) {
 	res, _ := client.AddAgentsToCluster(1, []int{8002})
 	exp := []Agent{
 		{
-			AgentID:   Int(1),
+			AgentID:   Int64(1),
 			AgentName: String("test"),
 			ClusterMembers: &[]ClusterMember{
 				{
-					MemberID: Int(80002),
+					MemberID: Int64(80002),
 					Name:     String("test"),
 				},
 			},

--- a/alert_test.go
+++ b/alert_test.go
@@ -18,7 +18,7 @@ func TestClient_GetAlertRule(t *testing.T) {
 
 	// Define expected values from the API (based on the JSON we print out above)
 	expected := AlertRules{
-		AlertRule{RuleID: Int(1), RuleName: String("test")},
+		AlertRule{RuleID: Int64(1), RuleName: String("test")},
 	}
 
 	res, err := client.GetAlertRules()
@@ -72,7 +72,7 @@ func TestClient_UpdateAlertRule(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expected := AlertRule{RuleID: Int(1), RuleName: String("test"), RoundsViolatingOutOf: Int(2), RoundsViolatingRequired: Int(1)}
+	expected := AlertRule{RuleID: Int64(1), RuleName: String("test"), RoundsViolatingOutOf: Int(2), RoundsViolatingRequired: Int(1)}
 	assert.Equal(t, &expected, res)
 }
 
@@ -91,7 +91,7 @@ func TestClient_CreateAlertRule(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expected := AlertRule{RuleID: Int(1), RuleName: String("test"), RoundsViolatingOutOf: Int(2), RoundsViolatingRequired: Int(1)}
+	expected := AlertRule{RuleID: Int64(1), RuleName: String("test"), RoundsViolatingOutOf: Int(2), RoundsViolatingRequired: Int(1)}
 	assert.Equal(t, &expected, res)
 }
 

--- a/alerts.go
+++ b/alerts.go
@@ -11,7 +11,7 @@ type Alerts []Alert
 
 // Alert - An alert
 type Alert struct {
-	AlertID        *int       `json:"alertId,omitempty"`
+	AlertID        *int64     `json:"alertId,omitempty"`
 	TestID         *int64     `json:"testId,omitempty"`
 	TestName       *string    `json:"testName,omitempty"`
 	Active         *int       `json:"active,omitempty"`
@@ -43,7 +43,7 @@ type Notification struct {
 
 // AlertRule - An alert rule
 type AlertRule struct {
-	AlertRuleID             *int          `json:"alertRuleId,omitempty"`
+	AlertRuleID             *int64        `json:"alertRuleId,omitempty"`
 	AlertType               *string       `json:"alertType,omitempty"`
 	Default                 *bool         `json:"default,omitempty" te:"int-bool"`
 	Direction               *string       `json:"direction,omitempty"`
@@ -55,7 +55,7 @@ type AlertRule struct {
 	RoundsViolatingMode     *string       `json:"roundsViolatingMode,omitempty"`
 	RoundsViolatingOutOf    *int          `json:"roundsViolatingOutOf,omitempty"`
 	RoundsViolatingRequired *int          `json:"roundsViolatingRequired,omitempty"`
-	RuleID                  *int          `json:"ruleId,omitempty"`
+	RuleID                  *int64        `json:"ruleId,omitempty"`
 	RuleName                *string       `json:"ruleName,omitempty"`
 	TestIds                 *[]int        `json:"testIds,omitempty"`
 	Notifications           *Notification `json:"notifications,omitempty"`

--- a/bgp.go
+++ b/bgp.go
@@ -62,8 +62,8 @@ func (t *BGP) UnmarshalJSON(data []byte) error {
 }
 
 // AddAlertRule - Adds an alert to agent test
-func (t *BGP) AddAlertRule(id int) {
-	alertRule := AlertRule{RuleID: Int(id)}
+func (t *BGP) AddAlertRule(id int64) {
+	alertRule := AlertRule{RuleID: Int64(id)}
 	*t.AlertRules = append(*t.AlertRules, alertRule)
 }
 

--- a/bgp_monitor.go
+++ b/bgp_monitor.go
@@ -7,7 +7,7 @@ type BGPMonitors []BGPMonitor
 
 // BGPMonitor - BGPMonitor struct
 type BGPMonitor struct {
-	MonitorID   *int    `json:"monitorId,omitempty"`
+	MonitorID   *int64  `json:"monitorId,omitempty"`
 	IPAddress   *string `json:"ipAddress,omitempty"`
 	Network     *string `json:"network,omitempty"`
 	MonitorType *string `json:"monitorType,omitempty"`

--- a/bgp_monitor_test.go
+++ b/bgp_monitor_test.go
@@ -19,7 +19,7 @@ func TestClient_GetBGPMonitors(t *testing.T) {
 
 	// Define expected values from the API (based on the JSON we print out above)
 	expected := BGPMonitors{
-		BGPMonitor{MonitorID: Int(1), MonitorName: String("test"), MonitorType: String("bgp"), IPAddress: String("1.2.3.4")},
+		BGPMonitor{MonitorID: Int64(1), MonitorName: String("test"), MonitorType: String("bgp"), IPAddress: String("1.2.3.4")},
 	}
 
 	res, err := client.GetBPGMonitors()

--- a/bgp_test.go
+++ b/bgp_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestClient_AddBGPAlertRule(t *testing.T) {
 	test := BGP{TestName: String("test"), AlertRules: &[]AlertRule{}}
-	expected := BGP{TestName: String("test"), AlertRules: &[]AlertRule{{RuleID: Int(1)}}}
+	expected := BGP{TestName: String("test"), AlertRules: &[]AlertRule{{RuleID: Int64(1)}}}
 	test.AddAlertRule(1)
 	assert.Equal(t, expected, test)
 }
@@ -37,7 +37,7 @@ func TestClient_GetBGP(t *testing.T) {
 		Prefix:        String("1.2.3.0/20"),
 		SharedWithAccounts: &[]SharedWithAccount{
 			{
-				AID:              Int(176592),
+				AID:              Int64(176592),
 				AccountGroupName: String("Cloudreach"),
 			},
 		},
@@ -108,7 +108,7 @@ func TestClient_CreateBGP(t *testing.T) {
 		AlertsEnabled: Bool(true),
 		SharedWithAccounts: &[]SharedWithAccount{
 			{
-				AID:              Int(176592),
+				AID:              Int64(176592),
 				AccountGroupName: String("Cloudreach"),
 			},
 		},

--- a/dns_dnssec.go
+++ b/dns_dnssec.go
@@ -61,14 +61,14 @@ func (t *DNSSec) UnmarshalJSON(data []byte) error {
 }
 
 // AddAgent - Add agent to DNSSec test
-func (t *DNSSec) AddAgent(id int) {
-	agent := Agent{AgentID: Int(id)}
+func (t *DNSSec) AddAgent(id int64) {
+	agent := Agent{AgentID: Int64(id)}
 	*t.Agents = append(*t.Agents, agent)
 }
 
 // AddAlertRule - Adds an alert to agent test
-func (t *DNSSec) AddAlertRule(id int) {
-	alertRule := AlertRule{RuleID: Int(id)}
+func (t *DNSSec) AddAlertRule(id int64) {
+	alertRule := AlertRule{RuleID: Int64(id)}
 	*t.AlertRules = append(*t.AlertRules, alertRule)
 }
 

--- a/dns_dnssec_test.go
+++ b/dns_dnssec_test.go
@@ -30,7 +30,7 @@ func TestClient_GetDNSSec(t *testing.T) {
 		Domain:        String("webex.com"),
 		Agents: &[]Agent{
 			{
-				AgentID:     Int(48620),
+				AgentID:     Int64(48620),
 				AgentType:   String("Cloud"),
 				AgentName:   String("Seattle, WA (Trial) - IPv6"),
 				CountryID:   String("US"),
@@ -42,7 +42,7 @@ func TestClient_GetDNSSec(t *testing.T) {
 		},
 		SharedWithAccounts: &[]SharedWithAccount{
 			{
-				AID:              Int(176592),
+				AID:              Int64(176592),
 				AccountGroupName: String("Cloudreach"),
 			},
 		},
@@ -113,7 +113,7 @@ func TestClient_CreateDNSSec(t *testing.T) {
 		Domain:        String("webex.com"),
 		Agents: &[]Agent{
 			{
-				AgentID:     Int(48620),
+				AgentID:     Int64(48620),
 				AgentType:   String("Cloud"),
 				AgentName:   String("Seattle, WA (Trial) - IPv6"),
 				CountryID:   String("US"),
@@ -125,7 +125,7 @@ func TestClient_CreateDNSSec(t *testing.T) {
 		},
 		SharedWithAccounts: &[]SharedWithAccount{
 			{
-				AID:              Int(176592),
+				AID:              Int64(176592),
 				AccountGroupName: String("Cloudreach"),
 			},
 		},
@@ -182,7 +182,7 @@ func TestClient_DeleteDNSSec(t *testing.T) {
 
 func TestClient_AddDNSSecAlertRule(t *testing.T) {
 	test := DNSSec{TestName: String("test"), AlertRules: &[]AlertRule{}}
-	expected := DNSSec{TestName: String("test"), AlertRules: &[]AlertRule{{RuleID: Int(1)}}}
+	expected := DNSSec{TestName: String("test"), AlertRules: &[]AlertRule{{RuleID: Int64(1)}}}
 	test.AddAlertRule(1)
 	assert.Equal(t, expected, test)
 }
@@ -209,7 +209,7 @@ func TestClient_UpdateDNSSec(t *testing.T) {
 
 func TestDNSSec_AddAgent(t *testing.T) {
 	test := DNSSec{TestName: String("test"), Agents: &[]Agent{}}
-	expected := DNSSec{TestName: String("test"), Agents: &[]Agent{{AgentID: Int(1)}}}
+	expected := DNSSec{TestName: String("test"), Agents: &[]Agent{{AgentID: Int64(1)}}}
 	test.AddAgent(1)
 	assert.Equal(t, expected, test)
 }

--- a/dns_server.go
+++ b/dns_server.go
@@ -7,7 +7,7 @@ import (
 
 // Server - a server ?
 type Server struct {
-	ServerID   *int    `json:"serverId,omitempty"`
+	ServerID   *int64  `json:"serverId,omitempty"`
 	ServerName *string `json:"serverName,omitempty"`
 }
 
@@ -80,14 +80,14 @@ func (t *DNSServer) UnmarshalJSON(data []byte) error {
 }
 
 // AddAgent - Add dns server test
-func (t *DNSServer) AddAgent(id int) {
-	agent := Agent{AgentID: Int(id)}
+func (t *DNSServer) AddAgent(id int64) {
+	agent := Agent{AgentID: Int64(id)}
 	*t.Agents = append(*t.Agents, agent)
 }
 
 // AddAlertRule - Adds an alert to agent test
-func (t *DNSServer) AddAlertRule(id int) {
-	alertRule := AlertRule{RuleID: Int(id)}
+func (t *DNSServer) AddAlertRule(id int64) {
+	alertRule := AlertRule{RuleID: Int64(id)}
 	*t.AlertRules = append(*t.AlertRules, alertRule)
 }
 

--- a/dns_server_test.go
+++ b/dns_server_test.go
@@ -43,7 +43,7 @@ func TestClient_GetDNSServer(t *testing.T) {
 		DNSTransportProtocol:  String("UDP"),
 		Agents: &[]Agent{
 			{
-				AgentID:     Int(48620),
+				AgentID:     Int64(48620),
 				AgentType:   String("Cloud"),
 				AgentName:   String("Seattle, WA (Trial) - IPv6"),
 				CountryID:   String("US"),
@@ -55,19 +55,19 @@ func TestClient_GetDNSServer(t *testing.T) {
 		},
 		SharedWithAccounts: &[]SharedWithAccount{
 			{
-				AID:              Int(176592),
+				AID:              Int64(176592),
 				AccountGroupName: String("Cloudreach"),
 			},
 		},
 		DNSServers: &[]Server{
 			{
-				ServerID:   Int(123),
+				ServerID:   Int64(123),
 				ServerName: String("1.1.1.1"),
 			},
 		},
 		BGPMonitors: &[]BGPMonitor{
 			{
-				MonitorID:   Int(64),
+				MonitorID:   Int64(64),
 				IPAddress:   String("2001:240:100:ff::2497:2"),
 				MonitorName: String("Tokyo-3"),
 				Network:     String("IIJ Internet Initiative Japan Inc. (AS 2497)"),
@@ -106,7 +106,7 @@ func TestClient_GetDNSServer(t *testing.T) {
 
 func TestClient_AddDnsserverAlertRule(t *testing.T) {
 	test := DNSServer{TestName: String("test"), AlertRules: &[]AlertRule{}}
-	expected := DNSServer{TestName: String("test"), AlertRules: &[]AlertRule{{RuleID: Int(1)}}}
+	expected := DNSServer{TestName: String("test"), AlertRules: &[]AlertRule{{RuleID: Int64(1)}}}
 	test.AddAlertRule(1)
 	assert.Equal(t, expected, test)
 }
@@ -161,7 +161,7 @@ func TestClient_CreateDNSServer(t *testing.T) {
 		DNSTransportProtocol:  String("UDP"),
 		Agents: &[]Agent{
 			{
-				AgentID:     Int(48620),
+				AgentID:     Int64(48620),
 				AgentType:   String("Cloud"),
 				AgentName:   String("Seattle, WA (Trial) - IPv6"),
 				CountryID:   String("US"),
@@ -173,19 +173,19 @@ func TestClient_CreateDNSServer(t *testing.T) {
 		},
 		SharedWithAccounts: &[]SharedWithAccount{
 			{
-				AID:              Int(176592),
+				AID:              Int64(176592),
 				AccountGroupName: String("Cloudreach"),
 			},
 		},
 		DNSServers: &[]Server{
 			{
-				ServerID:   Int(123),
+				ServerID:   Int64(123),
 				ServerName: String("1.1.1.1"),
 			},
 		},
 		BGPMonitors: &[]BGPMonitor{
 			{
-				MonitorID:   Int(64),
+				MonitorID:   Int64(64),
 				IPAddress:   String("2001:240:100:ff::2497:2"),
 				MonitorName: String("Tokyo-3"),
 				Network:     String("IIJ Internet Initiative Japan Inc. (AS 2497)"),
@@ -266,7 +266,7 @@ func TestClient_UpdateDNSServer(t *testing.T) {
 
 func TestDNSServer_AddAgent(t *testing.T) {
 	test := DNSServer{TestName: String("test"), Agents: &[]Agent{}}
-	expected := DNSServer{TestName: String("test"), Agents: &[]Agent{{AgentID: Int(1)}}}
+	expected := DNSServer{TestName: String("test"), Agents: &[]Agent{{AgentID: Int64(1)}}}
 	test.AddAgent(1)
 	assert.Equal(t, expected, test)
 }

--- a/dns_trace.go
+++ b/dns_trace.go
@@ -62,14 +62,14 @@ func (t *DNSTrace) UnmarshalJSON(data []byte) error {
 }
 
 // AddAgent - Add agent to DNS Trace test
-func (t *DNSTrace) AddAgent(id int) {
-	agent := Agent{AgentID: Int(id)}
+func (t *DNSTrace) AddAgent(id int64) {
+	agent := Agent{AgentID: Int64(id)}
 	*t.Agents = append(*t.Agents, agent)
 }
 
 // AddAlertRule - Adds an alert to agent test
-func (t *DNSTrace) AddAlertRule(id int) {
-	alertRule := AlertRule{RuleID: Int(id)}
+func (t *DNSTrace) AddAlertRule(id int64) {
+	alertRule := AlertRule{RuleID: Int64(id)}
 	*t.AlertRules = append(*t.AlertRules, alertRule)
 }
 

--- a/dns_trace_test.go
+++ b/dns_trace_test.go
@@ -32,7 +32,7 @@ func TestClient_GetDNSTrace(t *testing.T) {
 		DNSTransportProtocol: String("UDP"),
 		Agents: &[]Agent{
 			{
-				AgentID:     Int(48620),
+				AgentID:     Int64(48620),
 				AgentType:   String("Cloud"),
 				AgentName:   String("Seattle, WA (Trial) - IPv6"),
 				CountryID:   String("US"),
@@ -44,7 +44,7 @@ func TestClient_GetDNSTrace(t *testing.T) {
 		},
 		SharedWithAccounts: &[]SharedWithAccount{
 			{
-				AID:              Int(176592),
+				AID:              Int64(176592),
 				AccountGroupName: String("Cloudreach"),
 			},
 		},
@@ -119,7 +119,7 @@ func TestClient_CreateDNSTrace(t *testing.T) {
 		DNSTransportProtocol: String("UDP"),
 		Agents: &[]Agent{
 			{
-				AgentID:     Int(48620),
+				AgentID:     Int64(48620),
 				AgentType:   String("Cloud"),
 				AgentName:   String("Seattle, WA (Trial) - IPv6"),
 				CountryID:   String("US"),
@@ -131,7 +131,7 @@ func TestClient_CreateDNSTrace(t *testing.T) {
 		},
 		SharedWithAccounts: &[]SharedWithAccount{
 			{
-				AID:              Int(176592),
+				AID:              Int64(176592),
 				AccountGroupName: String("Cloudreach"),
 			},
 		},
@@ -189,7 +189,7 @@ func TestClient_DeleteDNSTrace(t *testing.T) {
 
 func TestClient_AddDnstraceAlertRule(t *testing.T) {
 	test := DNSTrace{TestName: String("test"), AlertRules: &[]AlertRule{}}
-	expected := DNSTrace{TestName: String("test"), AlertRules: &[]AlertRule{{RuleID: Int(1)}}}
+	expected := DNSTrace{TestName: String("test"), AlertRules: &[]AlertRule{{RuleID: Int64(1)}}}
 	test.AddAlertRule(1)
 	assert.Equal(t, expected, test)
 }
@@ -216,7 +216,7 @@ func TestClient_UpdateDNSTrace(t *testing.T) {
 
 func TestDNSTrace_AddAgent(t *testing.T) {
 	test := DNSTrace{TestName: String("test"), Agents: &[]Agent{}}
-	expected := DNSTrace{TestName: String("test"), Agents: &[]Agent{{AgentID: Int(1)}}}
+	expected := DNSTrace{TestName: String("test"), Agents: &[]Agent{{AgentID: Int64(1)}}}
 	test.AddAgent(1)
 	assert.Equal(t, expected, test)
 }

--- a/ftp_server.go
+++ b/ftp_server.go
@@ -76,14 +76,14 @@ func (t *FTPServer) UnmarshalJSON(data []byte) error {
 }
 
 // AddAgent - Add ftp server test
-func (t *FTPServer) AddAgent(id int) {
-	agent := Agent{AgentID: Int(id)}
+func (t *FTPServer) AddAgent(id int64) {
+	agent := Agent{AgentID: Int64(id)}
 	*t.Agents = append(*t.Agents, agent)
 }
 
 // AddAlertRule - Adds an alert to agent test
-func (t *FTPServer) AddAlertRule(id int) {
-	alertRule := AlertRule{RuleID: Int(id)}
+func (t *FTPServer) AddAlertRule(id int64) {
+	alertRule := AlertRule{RuleID: Int64(id)}
 	*t.AlertRules = append(*t.AlertRules, alertRule)
 }
 

--- a/ftp_server_test.go
+++ b/ftp_server_test.go
@@ -32,7 +32,7 @@ func TestClient_GetFTPServer(t *testing.T) {
 		ProbeMode:     String("AUTO"),
 		Agents: &[]Agent{
 			{
-				AgentID:     Int(48620),
+				AgentID:     Int64(48620),
 				AgentType:   String("Cloud"),
 				AgentName:   String("Seattle, WA (Trial) - IPv6"),
 				CountryID:   String("US"),
@@ -66,7 +66,7 @@ func TestClient_GetFTPServer(t *testing.T) {
 		},
 		SharedWithAccounts: &[]SharedWithAccount{
 			{
-				AID:              Int(176592),
+				AID:              Int64(176592),
 				AccountGroupName: String("Cloudreach"),
 			},
 		},
@@ -118,7 +118,7 @@ func TestClient_CreateFTPServer(t *testing.T) {
 		ProbeMode:     String("AUTO"),
 		Agents: &[]Agent{
 			{
-				AgentID:     Int(48620),
+				AgentID:     Int64(48620),
 				AgentType:   String("Cloud"),
 				AgentName:   String("Seattle, WA (Trial) - IPv6"),
 				CountryID:   String("US"),
@@ -130,7 +130,7 @@ func TestClient_CreateFTPServer(t *testing.T) {
 		},
 		SharedWithAccounts: &[]SharedWithAccount{
 			{
-				AID:              Int(176592),
+				AID:              Int64(176592),
 				AccountGroupName: String("Cloudreach"),
 			},
 		},
@@ -189,7 +189,7 @@ func TestClient_DeleteFTPServer(t *testing.T) {
 
 func TestClient_AddFTPServerAlertRule(t *testing.T) {
 	test := FTPServer{TestName: String("test"), AlertRules: &[]AlertRule{}}
-	expected := FTPServer{TestName: String("test"), AlertRules: &[]AlertRule{{RuleID: Int(1)}}}
+	expected := FTPServer{TestName: String("test"), AlertRules: &[]AlertRule{{RuleID: Int64(1)}}}
 	test.AddAlertRule(1)
 	assert.Equal(t, expected, test)
 }
@@ -216,7 +216,7 @@ func TestClient_UpdateFTPServer(t *testing.T) {
 
 func TestFTPServer_AddAgent(t *testing.T) {
 	test := FTPServer{TestName: String("test"), Agents: &[]Agent{}}
-	expected := FTPServer{TestName: String("test"), Agents: &[]Agent{{AgentID: Int(1)}}}
+	expected := FTPServer{TestName: String("test"), Agents: &[]Agent{{AgentID: Int64(1)}}}
 	test.AddAgent(1)
 	assert.Equal(t, expected, test)
 }

--- a/http_server.go
+++ b/http_server.go
@@ -65,7 +65,7 @@ type HTTPServer struct {
 	ProbeMode             *string        `json:"probeMode,omitempty"`
 	Protocol              *string        `json:"protocol,omitempty"`
 	SSLVersion            *string        `json:"sslVersion,omitempty"`
-	SSLVersionID          *int           `json:"sslVersionId,omitempty"`
+	SSLVersionID          *int64         `json:"sslVersionId,omitempty"`
 	URL                   *string        `json:"url,omitempty"`
 	UseNTLM               *bool          `json:"useNtlm,omitempty" te:"int-bool"` // TODO: BasicAuth not working
 	UserAgent             *string        `json:"userAgent,omitempty"`
@@ -103,8 +103,8 @@ func (t *HTTPServer) UnmarshalJSON(data []byte) error {
 }
 
 // AddAgent - add an agent
-func (t *HTTPServer) AddAgent(id int) {
-	agent := Agent{AgentID: Int(id)}
+func (t *HTTPServer) AddAgent(id int64) {
+	agent := Agent{AgentID: Int64(id)}
 	*t.Agents = append(*t.Agents, agent)
 }
 

--- a/http_server_test.go
+++ b/http_server_test.go
@@ -39,7 +39,7 @@ func TestClient_GetHTTPServer(t *testing.T) {
 		HTTPVersion:           Int(2),
 		FollowRedirects:       Bool(true),
 		NumPathTraces:         Int(3),
-		SSLVersionID:          Int(0),
+		SSLVersionID:          Int64(0),
 		VerifyCertificate:     Bool(true),
 		UseNTLM:               Bool(false),
 		AuthType:              String("NONE"),
@@ -47,7 +47,7 @@ func TestClient_GetHTTPServer(t *testing.T) {
 		ProbeMode:             String("AUTO"),
 		Agents: &[]Agent{
 			{
-				AgentID:     Int(48620),
+				AgentID:     Int64(48620),
 				AgentType:   String("Cloud"),
 				AgentName:   String("Seattle, WA (Trial) - IPv6"),
 				CountryID:   String("US"),
@@ -59,13 +59,13 @@ func TestClient_GetHTTPServer(t *testing.T) {
 		},
 		SharedWithAccounts: &[]SharedWithAccount{
 			{
-				AID:              Int(176592),
+				AID:              Int64(176592),
 				AccountGroupName: String("Cloudreach"),
 			},
 		},
 		BGPMonitors: &[]Monitor{
 			{
-				MonitorID:   Int(64),
+				MonitorID:   Int64(64),
 				IPAddress:   String("2001:240:100:ff::2497:2"),
 				CountryID:   String("JP"),
 				MonitorName: String("Tokyo-3"),
@@ -150,7 +150,7 @@ func TestClient_CreateHTTPServer(t *testing.T) {
 		HTTPVersion:           Int(2),
 		FollowRedirects:       Bool(true),
 		NumPathTraces:         Int(3),
-		SSLVersionID:          Int(0),
+		SSLVersionID:          Int64(0),
 		VerifyCertificate:     Bool(true),
 		UseNTLM:               Bool(false),
 		AuthType:              String("NONE"),
@@ -158,7 +158,7 @@ func TestClient_CreateHTTPServer(t *testing.T) {
 		ProbeMode:             String("AUTO"),
 		Agents: &[]Agent{
 			{
-				AgentID:     Int(48620),
+				AgentID:     Int64(48620),
 				AgentType:   String("Cloud"),
 				AgentName:   String("Seattle, WA (Trial) - IPv6"),
 				CountryID:   String("US"),
@@ -170,13 +170,13 @@ func TestClient_CreateHTTPServer(t *testing.T) {
 		},
 		SharedWithAccounts: &[]SharedWithAccount{
 			{
-				AID:              Int(176592),
+				AID:              Int64(176592),
 				AccountGroupName: String("Cloudreach"),
 			},
 		},
 		BGPMonitors: &[]Monitor{
 			{
-				MonitorID:   Int(64),
+				MonitorID:   Int64(64),
 				IPAddress:   String("2001:240:100:ff::2497:2"),
 				CountryID:   String("JP"),
 				MonitorName: String("Tokyo-3"),
@@ -258,7 +258,7 @@ func TestClient_UpdateHTTPServer(t *testing.T) {
 
 func TestHTTPServer_AddAgent(t *testing.T) {
 	test := HTTPServer{TestName: String("test"), Agents: &[]Agent{}}
-	expected := HTTPServer{TestName: String("test"), Agents: &[]Agent{{AgentID: Int(1)}}}
+	expected := HTTPServer{TestName: String("test"), Agents: &[]Agent{{AgentID: Int64(1)}}}
 	test.AddAgent(1)
 	assert.Equal(t, expected, test)
 }

--- a/monitors.go
+++ b/monitors.go
@@ -5,7 +5,7 @@ type Monitors []Monitor
 
 // Monitor - A monitor
 type Monitor struct {
-	MonitorID   *int    `json:"monitorId,omitempty"`
+	MonitorID   *int64  `json:"monitorId,omitempty"`
 	IPAddress   *string `json:"ipAddress,omitempty"`
 	CountryID   *string `json:"countryId,omitempty"`
 	MonitorName *string `json:"monitorName,omitempty"`

--- a/page_load.go
+++ b/page_load.go
@@ -50,7 +50,7 @@ type PageLoad struct {
 	ProbeMode             *string        `json:"probeMode,omitempty"`
 	Protocol              *string        `json:"protocol,omitempty"`
 	SSLVersion            *string        `json:"sslVersion,omitempty"`
-	SSLVersionID          *int           `json:"sslVersionId,omitempty"`
+	SSLVersionID          *int64         `json:"sslVersionId,omitempty"`
 	Subinterval           *int           `json:"subinterval,omitempty"`
 	URL                   *string        `json:"url,omitempty"`
 	UseNTLM               *bool          `json:"useNtlm,omitempty" te:"int-bool"`
@@ -90,8 +90,8 @@ func (t *PageLoad) UnmarshalJSON(data []byte) error {
 }
 
 // AddAgent  - add an aget
-func (t *PageLoad) AddAgent(id int) {
-	agent := Agent{AgentID: Int(id)}
+func (t *PageLoad) AddAgent(id int64) {
+	agent := Agent{AgentID: Int64(id)}
 	*t.Agents = append(*t.Agents, agent)
 }
 

--- a/page_load_test.go
+++ b/page_load_test.go
@@ -45,7 +45,7 @@ func TestClient_CreatePageLoad(t *testing.T) {
 		PageLoadTimeLimit:     Int(10),
 		PageLoadTargetTime:    Int(6),
 		IncludeHeaders:        Bool(true),
-		SSLVersionID:          Int(0),
+		SSLVersionID:          Int64(0),
 		VerifyCertificate:     Bool(true),
 		UseNTLM:               Bool(false),
 		AuthType:              String("NONE"),
@@ -53,7 +53,7 @@ func TestClient_CreatePageLoad(t *testing.T) {
 		ContentRegex:          String(""),
 		Agents: &[]Agent{
 			{
-				AgentID:     Int(48620),
+				AgentID:     Int64(48620),
 				AgentType:   String("Cloud"),
 				AgentName:   String("Seattle, WA (Trial) - IPv6"),
 				CountryID:   String("US"),
@@ -65,13 +65,13 @@ func TestClient_CreatePageLoad(t *testing.T) {
 		},
 		SharedWithAccounts: &[]SharedWithAccount{
 			{
-				AID:              Int(176592),
+				AID:              Int64(176592),
 				AccountGroupName: String("Cloudreach"),
 			},
 		},
 		BGPMonitors: &[]BGPMonitor{
 			{
-				MonitorID:   Int(62),
+				MonitorID:   Int64(62),
 				IPAddress:   String("2001:1890:111d:1::63"),
 				MonitorName: String("New York, NY-6"),
 				Network:     String("AT&T Services, Inc. (AS 7018)"),
@@ -152,7 +152,7 @@ func TestClient_GetPageLoad(t *testing.T) {
 		PageLoadTimeLimit:     Int(10),
 		PageLoadTargetTime:    Int(6),
 		IncludeHeaders:        Bool(true),
-		SSLVersionID:          Int(0),
+		SSLVersionID:          Int64(0),
 		VerifyCertificate:     Bool(true),
 		UseNTLM:               Bool(false),
 		AuthType:              String("NONE"),
@@ -160,7 +160,7 @@ func TestClient_GetPageLoad(t *testing.T) {
 		ContentRegex:          String(""),
 		Agents: &[]Agent{
 			{
-				AgentID:     Int(48620),
+				AgentID:     Int64(48620),
 				AgentType:   String("Cloud"),
 				AgentName:   String("Seattle, WA (Trial) - IPv6"),
 				CountryID:   String("US"),
@@ -172,13 +172,13 @@ func TestClient_GetPageLoad(t *testing.T) {
 		},
 		SharedWithAccounts: &[]SharedWithAccount{
 			{
-				AID:              Int(176592),
+				AID:              Int64(176592),
 				AccountGroupName: String("Cloudreach"),
 			},
 		},
 		BGPMonitors: &[]BGPMonitor{
 			{
-				MonitorID:   Int(62),
+				MonitorID:   Int64(62),
 				IPAddress:   String("2001:1890:111d:1::63"),
 				MonitorName: String("New York, NY-6"),
 				Network:     String("AT&T Services, Inc. (AS 7018)"),
@@ -258,7 +258,7 @@ func TestClient_UpdatePageLoad(t *testing.T) {
 
 func TestPageLoad_AddAgent(t *testing.T) {
 	test := PageLoad{TestName: String("test"), Agents: &[]Agent{}}
-	expected := PageLoad{TestName: String("test"), Agents: &[]Agent{{AgentID: Int(1)}}}
+	expected := PageLoad{TestName: String("test"), Agents: &[]Agent{{AgentID: Int64(1)}}}
 	test.AddAgent(1)
 	assert.Equal(t, expected, test)
 }

--- a/role.go
+++ b/role.go
@@ -8,7 +8,7 @@ import (
 // AccountGroupRole - an account group role
 type AccountGroupRole struct {
 	RoleName                 *string       `json:"roleName,omitempty"`
-	RoleID                   *int          `json:"roleId,omitempty"`
+	RoleID                   *int64        `json:"roleId,omitempty"`
 	HasManagementPermissions *bool         `json:"hasManagementPermissions,omitempty" te:"int-bool"`
 	Builtin                  *bool         `json:"builtin,omitempty" te:"int-bool"`
 	Permissions              *[]Permission `json:"permissions,omitempty"`
@@ -18,7 +18,7 @@ type AccountGroupRole struct {
 type Permission struct {
 	IsManagementPermission *bool   `json:"isManagementPermission" te:"int-bool"`
 	Label                  *string `json:"label"`
-	PermissionID           *int    `json:"permissionId"`
+	PermissionID           *int64  `json:"permissionId"`
 }
 
 // MarshalJSON implements the json.Marshaler interface. It ensures

--- a/role_test.go
+++ b/role_test.go
@@ -24,13 +24,13 @@ func TestClient_GetRoles(t *testing.T) {
 	expected := []AccountGroupRole{
 		{
 			RoleName:                 String("admin"),
-			RoleID:                   Int(2),
+			RoleID:                   Int64(2),
 			HasManagementPermissions: Bool(false),
 			Builtin:                  Bool(false),
 		},
 		{
 			RoleName:                 String("user1"),
-			RoleID:                   Int(1),
+			RoleID:                   Int64(1),
 			HasManagementPermissions: Bool(true),
 			Builtin:                  Bool(true),
 		},
@@ -55,7 +55,7 @@ func TestClient_GetRole(t *testing.T) {
 	}
 	expected := AccountGroupRole{
 		RoleName:                 String("admin"),
-		RoleID:                   Int(1),
+		RoleID:                   Int64(1),
 		HasManagementPermissions: Bool(false),
 		Builtin:                  Bool(false),
 	}
@@ -85,7 +85,7 @@ func TestClient_CreateRole(t *testing.T) {
 		RoleName:                 String("ThousandEyes SRE"),
 		HasManagementPermissions: Bool(true),
 		Builtin:                  Bool(false),
-		RoleID:                   Int(1000),
+		RoleID:                   Int64(1000),
 	}
 	assert.Equal(t, &expected, res)
 }
@@ -123,7 +123,7 @@ func TestClient_UpdateRole(t *testing.T) {
 
 	expected := AccountGroupRole{
 		RoleName:                 String("ThousandEyes SRE"),
-		RoleID:                   Int(1000),
+		RoleID:                   Int64(1000),
 		HasManagementPermissions: Bool(true),
 		Builtin:                  Bool(false),
 	}

--- a/sip_server.go
+++ b/sip_server.go
@@ -86,14 +86,14 @@ func (t *SIPServer) UnmarshalJSON(data []byte) error {
 }
 
 // AddAgent - Add agemt to sip server  test
-func (t *SIPServer) AddAgent(id int) {
-	agent := Agent{AgentID: Int(id)}
+func (t *SIPServer) AddAgent(id int64) {
+	agent := Agent{AgentID: Int64(id)}
 	*t.Agents = append(*t.Agents, agent)
 }
 
 // AddAlertRule - Adds an alert to agent test
-func (t *SIPServer) AddAlertRule(id int) {
-	alertRule := AlertRule{RuleID: Int(id)}
+func (t *SIPServer) AddAlertRule(id int64) {
+	alertRule := AlertRule{RuleID: Int64(id)}
 	*t.AlertRules = append(*t.AlertRules, alertRule)
 }
 

--- a/sip_server_test.go
+++ b/sip_server_test.go
@@ -30,7 +30,7 @@ func TestClient_GetSIPServer(t *testing.T) {
 		LiveShare:     Bool(false),
 		Agents: &[]Agent{
 			{
-				AgentID:     Int(48620),
+				AgentID:     Int64(48620),
 				AgentType:   String("Cloud"),
 				AgentName:   String("Seattle, WA (Trial) - IPv6"),
 				CountryID:   String("US"),
@@ -42,7 +42,7 @@ func TestClient_GetSIPServer(t *testing.T) {
 		},
 		SharedWithAccounts: &[]SharedWithAccount{
 			{
-				AID:              Int(176592),
+				AID:              Int64(176592),
 				AccountGroupName: String("Cloudreach"),
 			},
 		},
@@ -114,7 +114,7 @@ func TestClient_CreateSIPServer(t *testing.T) {
 		LiveShare:     Bool(false),
 		Agents: &[]Agent{
 			{
-				AgentID:     Int(48620),
+				AgentID:     Int64(48620),
 				AgentType:   String("Cloud"),
 				AgentName:   String("Seattle, WA (Trial) - IPv6"),
 				CountryID:   String("US"),
@@ -126,7 +126,7 @@ func TestClient_CreateSIPServer(t *testing.T) {
 		},
 		SharedWithAccounts: &[]SharedWithAccount{
 			{
-				AID:              Int(176592),
+				AID:              Int64(176592),
 				AccountGroupName: String("Cloudreach"),
 			},
 		},
@@ -205,13 +205,13 @@ func TestClient_UpdateSIPServer(t *testing.T) {
 
 func TestSIPServer_AddAgent(t *testing.T) {
 	test := SIPServer{TestName: String("test"), Agents: &[]Agent{}}
-	expected := SIPServer{TestName: String("test"), Agents: &[]Agent{{AgentID: Int(1)}}}
+	expected := SIPServer{TestName: String("test"), Agents: &[]Agent{{AgentID: Int64(1)}}}
 	test.AddAgent(1)
 	assert.Equal(t, expected, test)
 }
 func TestClient_AddSIPServerAlertRule(t *testing.T) {
 	test := SIPServer{TestName: String("test"), AlertRules: &[]AlertRule{}}
-	expected := SIPServer{TestName: String("test"), AlertRules: &[]AlertRule{{RuleID: Int(1)}}}
+	expected := SIPServer{TestName: String("test"), AlertRules: &[]AlertRule{{RuleID: Int64(1)}}}
 	test.AddAlertRule(1)
 	assert.Equal(t, expected, test)
 }

--- a/users.go
+++ b/users.go
@@ -9,7 +9,7 @@ import (
 type User struct {
 	Name                 *string             `json:"name,omitempty"`
 	Email                *string             `json:"email,omitempty"`
-	UID                  *int                `json:"uid,omitempty"`
+	UID                  *int64              `json:"uid,omitempty"`
 	LastLogin            *time.Time          `json:"lastLogin,omitempty"`
 	DateRegistered       *time.Time          `json:"dateRegistered,omitempty"`
 	LoginAccountGroup    *AccountGroup       `json:"loginAccountGroup,omitempty"`

--- a/users_test.go
+++ b/users_test.go
@@ -25,12 +25,12 @@ func TestClient_GetUsers(t *testing.T) {
 		{
 			Name:  String("ThousandEyes SRE"),
 			Email: String("test.example@thousandeyes.com"),
-			UID:   Int(1),
+			UID:   Int64(1),
 		},
 		{
 			Name:  String("Test User 2"),
 			Email: String("test.example@thousandeyes.com"),
-			UID:   Int(2),
+			UID:   Int64(2),
 		},
 	}
 	assert.Equal(t, &expected, res)
@@ -54,7 +54,7 @@ func TestClient_GetUser(t *testing.T) {
 	expected := User{
 		Name:  String("ThousandEyes SRE"),
 		Email: String("test.example@thousandeyes.com"),
-		UID:   Int(1),
+		UID:   Int64(1),
 	}
 	assert.Equal(t, &expected, res)
 }
@@ -81,7 +81,7 @@ func TestClient_CreateUser(t *testing.T) {
 	expected := User{
 		Name:  String("ThousandEyes SRE"),
 		Email: String("test.example@thousandeyes.com"),
-		UID:   Int(1),
+		UID:   Int64(1),
 	}
 	assert.Equal(t, &expected, res)
 }
@@ -119,7 +119,7 @@ func TestClient_UpdateUser(t *testing.T) {
 	expected := User{
 		Name:  String("ThousandEyes SRE"),
 		Email: String("text.example@thousandeyes.com"),
-		UID:   Int(1),
+		UID:   Int64(1),
 	}
 	assert.Equal(t, &expected, res)
 }

--- a/voice.go
+++ b/voice.go
@@ -32,15 +32,15 @@ type RTPStream struct {
 	BGPMeasurements *bool         `json:"bgpMeasurements,omitempty" te:"int-bool"`
 	BGPMonitors     *[]BGPMonitor `json:"bgpMonitors,omitempty"`
 	Codec           *string       `json:"codec,omitempty"`
-	CodecID         *int          `json:"codecId,omitempty"`
+	CodecID         *int64        `json:"codecId,omitempty"`
 	DSCP            *string       `json:"dscp,omitempty"`
-	DSCPID          *int          `json:"dscpId,omitempty"`
+	DSCPID          *int64        `json:"dscpId,omitempty"`
 	Duration        *int          `json:"duration,omitempty"`
 	Interval        *int          `json:"interval,omitempty"`
 	JitterBuffer    *int          `json:"jitterBuffer,omitempty"`
 	MTUMeasurements *bool         `json:"mtuMeasurements,omitempty" te:"int-bool"`
 	NumPathTraces   *int          `json:"numPathTraces,omitempty"`
-	TargetAgentID   *int          `json:"targetAgentId,omitempty"`
+	TargetAgentID   *int64        `json:"targetAgentId,omitempty"`
 	UsePublicBGP    *bool         `json:"usePublicBgp,omitempty" te:"int-bool"`
 	// server field is present in response, but we should not track it.
 	//Server          *string       `json:"server,omitempty"`
@@ -76,8 +76,8 @@ func (t *RTPStream) UnmarshalJSON(data []byte) error {
 }
 
 // AddAgent - Add agent to voice call  test
-func (t *RTPStream) AddAgent(id int) {
-	agent := Agent{AgentID: Int(id)}
+func (t *RTPStream) AddAgent(id int64) {
+	agent := Agent{AgentID: Int64(id)}
 	*t.Agents = append(*t.Agents, agent)
 }
 

--- a/voice_test.go
+++ b/voice_test.go
@@ -31,13 +31,13 @@ func TestClient_GetRTPStream(t *testing.T) {
 		JitterBuffer:    Int(40),
 		ModifiedDate:    String("2019-02-06 01:09:56"),
 		ModifiedBy:      String("ThousandEyes (support@thousandeyes.com)"),
-		TargetAgentID:   Int(69),
+		TargetAgentID:   Int64(69),
 		Codec:           String("G.711 @ 64 Kbps"),
-		CodecID:         Int(0),
+		CodecID:         Int64(0),
 		BGPMeasurements: Bool(true),
 		UsePublicBGP:    Bool(true),
 		DSCP:            String("EF (DSCP 46)"),
-		DSCPID:          Int(46),
+		DSCPID:          Int64(46),
 		NumPathTraces:   Int(3),
 		APILinks: &[]APILink{
 
@@ -101,13 +101,13 @@ func TestClient_CreateRTPStream(t *testing.T) {
 		TestName:        String("RTP Stream - AWS RTP server"),
 		Interval:        Int(120),
 		AlertsEnabled:   Bool(false),
-		DSCPID:          Int(46),
+		DSCPID:          Int64(46),
 		Duration:        Int(5),
 		BGPMeasurements: Bool(true),
 		UsePublicBGP:    Bool(true),
 		NumPathTraces:   Int(3),
 		Codec:           String("G.711 @ 64 Kbps"),
-		CodecID:         Int(0),
+		CodecID:         Int64(0),
 		APILinks: &[]APILink{
 			{
 				Href: String("https://api.thousandeyes.com/v6/tests/814641"),
@@ -129,7 +129,7 @@ func TestClient_CreateRTPStream(t *testing.T) {
 	}
 	create := RTPStream{
 		TestName: String("test1"),
-		DSCPID:   Int(46),
+		DSCPID:   Int64(46),
 		Duration: Int(5),
 		Interval: Int(120),
 		Codec:    String("G.711 @ 64 Kbps"),
@@ -169,7 +169,7 @@ func TestClient_UpdateRTPStream(t *testing.T) {
 	id := 1
 	sipS := RTPStream{
 		TestName:     String("RTP Stream - AWS RTP server"),
-		CodecID:      Int(0),
+		CodecID:      Int64(0),
 		Codec:        String("G.711 @ 64 Kbps"),
 		JitterBuffer: Int(40),
 	}
@@ -177,14 +177,14 @@ func TestClient_UpdateRTPStream(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expected := RTPStream{AlertsEnabled: Bool(false), Interval: Int(120), TestID: Int64(1234), Codec: String("G.711 @ 64 Kbps"), TestName: String("RTP Stream - AWS RTP server"), CodecID: Int(0), JitterBuffer: Int(40)}
+	expected := RTPStream{AlertsEnabled: Bool(false), Interval: Int(120), TestID: Int64(1234), Codec: String("G.711 @ 64 Kbps"), TestName: String("RTP Stream - AWS RTP server"), CodecID: Int64(0), JitterBuffer: Int(40)}
 	assert.Equal(t, &expected, res)
 
 }
 
 func TestRTPStream_AddAgent(t *testing.T) {
 	test := RTPStream{TestName: String("test"), Agents: &[]Agent{}}
-	expected := RTPStream{TestName: String("test"), Agents: &[]Agent{{AgentID: Int(1)}}}
+	expected := RTPStream{TestName: String("test"), Agents: &[]Agent{{AgentID: Int64(1)}}}
 	test.AddAgent(1)
 	assert.Equal(t, expected, test)
 }

--- a/web_transaction.go
+++ b/web_transaction.go
@@ -45,7 +45,7 @@ type WebTransaction struct {
 	PathTraceMode         *string        `json:"pathTraceMode,omitempty"`
 	ProbeMode             *string        `json:"probeMode,omitempty"`
 	Protocol              *string        `json:"protocol,omitempty"`
-	SSLVersionID          *int           `json:"sslVersionId,omitempty"`
+	SSLVersionID          *int64         `json:"sslVersionId,omitempty"`
 	SubInterval           *int           `json:"subinterval,omitempty"`
 	TargetTime            *int           `json:"targetTime,omitempty"`
 	TimeLimit             *int           `json:"timeLimit,omitempty"`


### PR DESCRIPTION
Future-proof IDs by making them int64.