### PR TITLE
feat: adds configurable user-agent header to HTTP client

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -55,6 +55,25 @@ func Test_ClientAccountGroupNone(t *testing.T) {
 	_, _ = client.GetAgents()
 }
 
+func Test_ClientUserAgentHeader(t *testing.T) {
+	setup()
+
+	// test default user-agent
+	mux.HandleFunc("/agents.json", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "ThousandEyes Go SDK", r.Header.Get("user-agent"))
+		_, _ = w.Write([]byte(`{"agents": []}`))
+	})
+	_, _ = client.GetAgents()
+
+	// test custom user-agent
+	client = &Client{APIEndpoint: server.URL, AuthToken: "foo", UserAgent: "porto"}
+	mux.HandleFunc("/alert-rules.json", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "porto", r.Header.Get("user-agent"))
+		_, _ = w.Write([]byte(`{"alert-rules": []}`))
+	})
+	_, _ = client.GetAlertRules()
+}
+
 func Test_setDelay(t *testing.T) {
 	setup()
 	now := time.Now()


### PR DESCRIPTION
Defaults to "ThousandEyes Go SDK"

Tests run successfully:
```
go vet ./... && echo && go test ./...

ok  	github.com/thousandeyes/thousandeyes-sdk-go/v2	1.161s
```

Tested in the terraform provider locally too:
```
go vet ./... && echo && go test ./...

?   	github.com/thousandeyes/terraform-provider-thousandeyes	[no test files]
ok  	github.com/thousandeyes/terraform-provider-thousandeyes/thousandeyes	0.422s
```

Terraform Plan with provider development override also worked well:
```
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - thousandeyes/thousandeyes in /Users/pedrorg/go/bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
thousandeyes_label.tf: Refreshing state... [id=410351]
thousandeyes_alert_rule.test_alert_rule-2: Refreshing state... [id=4946550]
thousandeyes_dns_server.example_dns_server_test: Refreshing state... [id=3027162]
thousandeyes_agent_to_server.google_agent_to_server: Refreshing state... [id=3026865]
thousandeyes_agent_to_agent.example_agent_to_agent: Refreshing state... [id=3026866]
thousandeyes_sip_server.sip_server_example: Refreshing state... [id=3026862]
thousandeyes_alert_rule.test_alert_rule: Refreshing state... [id=4946549]
thousandeyes_voice.webex_rtp_example: Refreshing state... [id=3026905]
thousandeyes_page_load.test: Refreshing state... [id=3026863]
thousandeyes_http_server.www_thousandeyes_http_test: Refreshing state... [id=3026864]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
```