### PR TITLE
Implement third party notification support within alerts

### DIFF
--- a/alert_test.go
+++ b/alert_test.go
@@ -95,6 +95,58 @@ func TestClient_CreateAlertRule(t *testing.T) {
 	assert.Equal(t, &expected, res)
 }
 
+func TestClient_CreateAlertRuleWithNotifications(t *testing.T) {
+	setup()
+	out := `{"alertRuleId": 1, "ruleName": "test", "notifications":{"thirdParty":[{"integrationId": "1", "integrationName": "foo", "integrationType":"bar"},{"integrationId": "2", "integrationName": "foo2", "integrationType":"bar2"}]}}`
+	mux.HandleFunc("/alert-rules/new.json", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(out))
+	})
+
+	var client = &Client{APIEndpoint: server.URL, AuthToken: "foo"}
+	u := AlertRule{
+		RuleName: String("test"),
+		Notifications: &Notification{
+			ThirdParty: &[]NotificationThirdParty{
+				{
+					IntegrationID:   String("1"),
+					IntegrationName: String("foo"),
+					IntegrationType: String("bar"),
+				},
+				{
+					IntegrationID:   String("2"),
+					IntegrationName: String("foo2"),
+					IntegrationType: String("bar2"),
+				},
+			},
+		},
+	}
+	res, err := client.CreateAlertRule(u)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := AlertRule{
+		RuleID:   Int64(1),
+		RuleName: String("test"),
+		Notifications: &Notification{
+			ThirdParty: &[]NotificationThirdParty{
+				{
+					IntegrationID:   String("1"),
+					IntegrationName: String("foo"),
+					IntegrationType: String("bar"),
+				},
+				{
+					IntegrationID:   String("2"),
+					IntegrationName: String("foo2"),
+					IntegrationType: String("bar2"),
+				},
+			},
+		},
+	}
+	assert.Equal(t, &expected, res)
+}
+
 func TestClient_AlertJsonError(t *testing.T) {
 	out := `{"alertRules": [test]}`
 	setup()

--- a/alerts.go
+++ b/alerts.go
@@ -36,9 +36,22 @@ type NotificationEmail struct {
 	Recipient *[]string `json:"recipient,omitempty"`
 }
 
+// NotificationThirdParty - Alert Rule Notification ThirdParty structure
+type NotificationThirdParty struct {
+	IntegrationID   *string `json:"integrationId,omitempty"`
+	IntegrationName *string `json:"integrationName,omitempty"`
+	IntegrationType *string `json:"integrationType,omitempty"`
+	Target          *string `json:"target,omitempty"`
+	AuthMethod      *string `json:"authMethod,omitempty"`
+	AuthUser        *string `json:"authUser,omitempty"`
+	AuthToken       *string `json:"authToken,omitempty"`
+	Channel         *string `json:"channel,omitempty"`
+}
+
 // Notification - Alert Rule Notification structure
 type Notification struct {
-	Email *NotificationEmail `json:"email,omitempty"`
+	Email      *NotificationEmail        `json:"email,omitempty"`
+	ThirdParty *[]NotificationThirdParty `json:"thirdParty,omitempty"`
 }
 
 // AlertRule - An alert rule
@@ -113,7 +126,7 @@ func (c Client) CreateAlertRule(a AlertRule) (*AlertRule, error) {
 	return &target, nil
 }
 
-//GetAlertRules - Get alert rules
+// GetAlertRules - Get alert rules
 func (c Client) GetAlertRules() (*AlertRules, error) {
 	resp, err := c.get(fmt.Sprintf("/alert-rules"))
 	if err != nil {
@@ -150,7 +163,7 @@ func (c *Client) GetAlertRule(id int64) (*AlertRule, error) {
 	return &target["alertRules"][0], nil
 }
 
-//DeleteAlertRule - delete alert rule
+// DeleteAlertRule - delete alert rule
 func (c Client) DeleteAlertRule(id int64) error {
 	resp, err := c.post(fmt.Sprintf("/alert-rules/%d/delete", id), nil, nil)
 	if err != nil {
@@ -162,7 +175,7 @@ func (c Client) DeleteAlertRule(id int64) error {
 	return nil
 }
 
-//UpdateAlertRule - update alert rule
+// UpdateAlertRule - update alert rule
 func (c Client) UpdateAlertRule(id int64, a AlertRule) (*AlertRule, error) {
 	resp, err := c.post(fmt.Sprintf("/alert-rules/%d/update", id), a, nil)
 	if err != nil {


### PR DESCRIPTION
Added necessary structs to support third party notifications (via slack, pagerduty, etc) in alerts. This feature is lacking in your new-ish terraform provider and would be of great use. I used your API docs as reference: https://developer.thousandeyes.com/v6/alerts/#/alert-rule-create

I suppose a follow-up pull request on your provider using a newer version of this SDK will need to happen later. Let me know if anything else is needed and if I can facilitate any work to speed things up.

Thanks for your work. 🙇🏼 