### PR TITLE
feat: allows overriding the API Endpoint

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -33,7 +33,7 @@ type Agent struct {
 	TargetForTests        *string              `json:"targetForTests,omitempty"`
 }
 
-//ClusterMember - ClusterMember struct
+// ClusterMember - ClusterMember struct
 type ClusterMember struct {
 	MemberID          *int64    `json:"memberId,omitempty"`
 	Name              *string   `json:"name,omitempty"`

--- a/agent_agent.go
+++ b/agent_agent.go
@@ -117,7 +117,7 @@ func (c Client) CreateAgentAgent(t AgentAgent) (*AgentAgent, error) {
 	return &target["test"][0], nil
 }
 
-//DeleteAgentAgent - delete agent to agent test
+// DeleteAgentAgent - delete agent to agent test
 func (c *Client) DeleteAgentAgent(id int64) error {
 	resp, err := c.post(fmt.Sprintf("/tests/agent-to-agent/%d/delete", id), nil, nil)
 	if err != nil {

--- a/bgp.go
+++ b/bgp.go
@@ -80,7 +80,7 @@ func (c *Client) GetBGP(id int64) (*BGP, error) {
 	return &target["test"][0], nil
 }
 
-//CreateBGP - Create bgp test
+// CreateBGP - Create bgp test
 func (c Client) CreateBGP(t BGP) (*BGP, error) {
 	resp, err := c.post("/tests/bgp/new", t, nil)
 	if err != nil {
@@ -96,7 +96,7 @@ func (c Client) CreateBGP(t BGP) (*BGP, error) {
 	return &target["test"][0], nil
 }
 
-//DeleteBGP - delete bgp test
+// DeleteBGP - delete bgp test
 func (c *Client) DeleteBGP(id int64) error {
 	resp, err := c.post(fmt.Sprintf("/tests/bgp/%d/delete", id), nil, nil)
 	if err != nil {
@@ -108,7 +108,7 @@ func (c *Client) DeleteBGP(id int64) error {
 	return nil
 }
 
-//UpdateBGP - - Update bgp trace test
+// UpdateBGP - - Update bgp trace test
 func (c *Client) UpdateBGP(id int64, t BGP) (*BGP, error) {
 	resp, err := c.post(fmt.Sprintf("/tests/bgp/%d/update", id), t, nil)
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	apiEndpoint = "https://api.thousandeyes.com/v6"
+	defaultAPIEndpoint = "https://api.thousandeyes.com/v6"
 )
 
 var orgRate RateLimit
@@ -53,13 +53,14 @@ type HTTPClient interface {
 	Do(*http.Request) (*http.Response, error)
 }
 
-// ClientOptions - Thousandeyes client options for accountID, AuthToken & rate limiter
-// and HTTP client settings
+// ClientOptions - Thousandeyes client options for apiEndpoint, accountID, AuthToken,
+// rate limiter, and HTTP client settings
 type ClientOptions struct {
-	Limiter   Limiter
-	AccountID string
-	AuthToken string
-	Timeout   time.Duration
+	APIEndpoint string
+	Limiter     Limiter
+	AccountID   string
+	AuthToken   string
+	Timeout     time.Duration
 	// http client user-agent
 	UserAgent string
 }
@@ -84,6 +85,10 @@ func (l DefaultLimiter) Wait() {
 
 // NewClient creates an API client
 func NewClient(opts *ClientOptions) *Client {
+	if opts.APIEndpoint == "" {
+		opts.APIEndpoint = defaultAPIEndpoint
+	}
+
 	// Set default timeout if a custom duration is 0 or unset (since we
 	// can't tell the difference without using an additional value).
 	// Overriding a default value of 0 has the side effect of preventing
@@ -103,7 +108,7 @@ func NewClient(opts *ClientOptions) *Client {
 	return &Client{
 		AuthToken:      opts.AuthToken,
 		AccountGroupID: opts.AccountID,
-		APIEndpoint:    apiEndpoint,
+		APIEndpoint:    opts.APIEndpoint,
 		HTTPClient: http.Client{
 			Timeout: timeout,
 		},

--- a/client_test.go
+++ b/client_test.go
@@ -59,6 +59,11 @@ func Test_ClientUserAgentHeader(t *testing.T) {
 	setup()
 
 	// test default user-agent
+	clientOpts := ClientOptions{
+		AuthToken:   "foo",
+		APIEndpoint: server.URL,
+	}
+	client = NewClient(&clientOpts)
 	mux.HandleFunc("/agents.json", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "ThousandEyes Go SDK", r.Header.Get("user-agent"))
 		_, _ = w.Write([]byte(`{"agents": []}`))
@@ -66,12 +71,40 @@ func Test_ClientUserAgentHeader(t *testing.T) {
 	_, _ = client.GetAgents()
 
 	// test custom user-agent
-	client = &Client{APIEndpoint: server.URL, AuthToken: "foo", UserAgent: "porto"}
+	clientOpts = ClientOptions{
+		AuthToken:   "foo",
+		APIEndpoint: server.URL,
+		UserAgent:   "porto",
+	}
+	client = NewClient(&clientOpts)
 	mux.HandleFunc("/alert-rules.json", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "porto", r.Header.Get("user-agent"))
 		_, _ = w.Write([]byte(`{"alert-rules": []}`))
 	})
 	_, _ = client.GetAlertRules()
+}
+
+func Test_ClientAPIEndpoint(t *testing.T) {
+	setup()
+
+	// by default if the APIEndpoint field in the client options is not set
+	// then the client defaults to "https://api.thousandeyes.com/v6"
+	clientOpts := ClientOptions{
+		AuthToken: "foo",
+		AccountID: "bar",
+	}
+	client = NewClient(&clientOpts)
+	assert.Equal(t, defaultAPIEndpoint, client.APIEndpoint)
+
+	// test overriding the APIEndpoint field of the client
+	overrideAPIEndpoint := "https://api.millioneyes.com/v9"
+	clientOpts = ClientOptions{
+		AuthToken:   "foo",
+		AccountID:   "bar",
+		APIEndpoint: overrideAPIEndpoint,
+	}
+	client = NewClient(&clientOpts)
+	assert.Equal(t, overrideAPIEndpoint, client.APIEndpoint)
 }
 
 func Test_setDelay(t *testing.T) {

--- a/dns_server.go
+++ b/dns_server.go
@@ -91,7 +91,7 @@ func (t *DNSServer) AddAlertRule(id int64) {
 	*t.AlertRules = append(*t.AlertRules, alertRule)
 }
 
-//GetDNSServer - get dns server test
+// GetDNSServer - get dns server test
 func (c *Client) GetDNSServer(id int64) (*DNSServer, error) {
 	resp, err := c.get(fmt.Sprintf("/tests/%d", id))
 	if err != nil {
@@ -120,7 +120,7 @@ func (c Client) CreateDNSServer(t DNSServer) (*DNSServer, error) {
 	return &target["test"][0], nil
 }
 
-//DeleteDNSServer - delete dns server test
+// DeleteDNSServer - delete dns server test
 func (c *Client) DeleteDNSServer(id int64) error {
 	resp, err := c.post(fmt.Sprintf("/tests/dns-server/%d/delete", id), nil, nil)
 	if err != nil {
@@ -132,7 +132,7 @@ func (c *Client) DeleteDNSServer(id int64) error {
 	return nil
 }
 
-//UpdateDNSServer - - Update dns server test
+// UpdateDNSServer - - Update dns server test
 func (c *Client) UpdateDNSServer(id int64, t DNSServer) (*DNSServer, error) {
 	resp, err := c.post(fmt.Sprintf("/tests/dns-server/%d/update", id), t, nil)
 	if err != nil {

--- a/dns_trace.go
+++ b/dns_trace.go
@@ -102,7 +102,7 @@ func (c Client) CreateDNSTrace(t DNSTrace) (*DNSTrace, error) {
 	return &target["test"][0], nil
 }
 
-//DeleteDNSTrace - delete dns trace test
+// DeleteDNSTrace - delete dns trace test
 func (c *Client) DeleteDNSTrace(id int64) error {
 	resp, err := c.post(fmt.Sprintf("/tests/dns-trace/%d/delete", id), nil, nil)
 	if err != nil {
@@ -114,7 +114,7 @@ func (c *Client) DeleteDNSTrace(id int64) error {
 	return nil
 }
 
-//UpdateDNSTrace - update dns trace test
+// UpdateDNSTrace - update dns trace test
 func (c *Client) UpdateDNSTrace(id int64, t DNSTrace) (*DNSTrace, error) {
 	resp, err := c.post(fmt.Sprintf("/tests/dns-trace/%d/update", id), t, nil)
 	if err != nil {

--- a/group_label.go
+++ b/group_label.go
@@ -113,7 +113,7 @@ func (c Client) CreateGroupLabel(a GroupLabel) (*GroupLabel, error) {
 	return &target["groups"][0], nil
 }
 
-//DeleteGroupLabel - delete label
+// DeleteGroupLabel - delete label
 func (c Client) DeleteGroupLabel(id int64) error {
 	resp, err := c.post(fmt.Sprintf("/groups/%d/delete", id), nil, nil)
 	if err != nil {
@@ -125,7 +125,7 @@ func (c Client) DeleteGroupLabel(id int64) error {
 	return nil
 }
 
-//UpdateGroupLabel - update label
+// UpdateGroupLabel - update label
 func (c Client) UpdateGroupLabel(id int64, a GroupLabel) (*GroupLabels, error) {
 	resp, err := c.post(fmt.Sprintf("/groups/%d/update", id), a, nil)
 	if err != nil {

--- a/http_server.go
+++ b/http_server.go
@@ -108,7 +108,7 @@ func (t *HTTPServer) AddAgent(id int64) {
 	*t.Agents = append(*t.Agents, agent)
 }
 
-//GetHTTPServer - Get an HTTP Server test
+// GetHTTPServer - Get an HTTP Server test
 func (c *Client) GetHTTPServer(id int64) (*HTTPServer, error) {
 	resp, err := c.get(fmt.Sprintf("/tests/%d", id))
 	if err != nil {
@@ -121,7 +121,7 @@ func (c *Client) GetHTTPServer(id int64) (*HTTPServer, error) {
 	return &target["test"][0], nil
 }
 
-//CreateHTTPServer - create a http server
+// CreateHTTPServer - create a http server
 func (c Client) CreateHTTPServer(t HTTPServer) (*HTTPServer, error) {
 	resp, err := c.post("/tests/http-server/new", t, nil)
 	if err != nil {
@@ -137,7 +137,7 @@ func (c Client) CreateHTTPServer(t HTTPServer) (*HTTPServer, error) {
 	return &target["test"][0], nil
 }
 
-//DeleteHTTPServer - delete an http server
+// DeleteHTTPServer - delete an http server
 func (c *Client) DeleteHTTPServer(id int64) error {
 	resp, err := c.post(fmt.Sprintf("/tests/http-server/%d/delete", id), nil, nil)
 	if err != nil {
@@ -149,7 +149,7 @@ func (c *Client) DeleteHTTPServer(id int64) error {
 	return nil
 }
 
-//UpdateHTTPServer - Update an http server test
+// UpdateHTTPServer - Update an http server test
 func (c *Client) UpdateHTTPServer(id int64, t HTTPServer) (*HTTPServer, error) {
 	resp, err := c.post(fmt.Sprintf("/tests/http-server/%d/update", id), t, nil)
 	if err != nil {

--- a/page_load.go
+++ b/page_load.go
@@ -95,7 +95,7 @@ func (t *PageLoad) AddAgent(id int64) {
 	*t.Agents = append(*t.Agents, agent)
 }
 
-//GetPageLoad - get page load test
+// GetPageLoad - get page load test
 func (c *Client) GetPageLoad(id int64) (*PageLoad, error) {
 	resp, err := c.get(fmt.Sprintf("/tests/%d", id))
 	if err != nil {
@@ -108,7 +108,7 @@ func (c *Client) GetPageLoad(id int64) (*PageLoad, error) {
 	return &target["test"][0], nil
 }
 
-//CreatePageLoad - create pager load test
+// CreatePageLoad - create pager load test
 func (c Client) CreatePageLoad(t PageLoad) (*PageLoad, error) {
 	resp, err := c.post("/tests/page-load/new", t, nil)
 	if err != nil {
@@ -136,7 +136,7 @@ func (c *Client) DeletePageLoad(id int64) error {
 	return nil
 }
 
-//UpdatePageLoad - Upload page load
+// UpdatePageLoad - Upload page load
 func (c *Client) UpdatePageLoad(id int64, t PageLoad) (*PageLoad, error) {
 	resp, err := c.post(fmt.Sprintf("/tests/page-load/%d/update", id), t, nil)
 	if err != nil {

--- a/sip_server.go
+++ b/sip_server.go
@@ -145,7 +145,7 @@ func (c *Client) GetSIPServer(id int64) (*SIPServer, error) {
 	return &target["test"][0], nil
 }
 
-//CreateSIPServer - Create sip server test
+// CreateSIPServer - Create sip server test
 func (c Client) CreateSIPServer(t SIPServer) (*SIPServer, error) {
 	resp, err := c.post("/tests/sip-server/new", t, nil)
 	if err != nil {
@@ -161,7 +161,7 @@ func (c Client) CreateSIPServer(t SIPServer) (*SIPServer, error) {
 	return &target["test"][0], nil
 }
 
-//DeleteSIPServer - delete sip server test
+// DeleteSIPServer - delete sip server test
 func (c *Client) DeleteSIPServer(id int64) error {
 	resp, err := c.post(fmt.Sprintf("/tests/sip-server/%d/delete", id), nil, nil)
 	if err != nil {
@@ -173,7 +173,7 @@ func (c *Client) DeleteSIPServer(id int64) error {
 	return nil
 }
 
-//UpdateSIPServer - - update sip server test
+// UpdateSIPServer - - update sip server test
 func (c *Client) UpdateSIPServer(id int64, t SIPServer) (*SIPServer, error) {
 	resp, err := c.post(fmt.Sprintf("/tests/sip-server/%d/update", id), t, nil)
 	if err != nil {

--- a/voice.go
+++ b/voice.go
@@ -94,7 +94,7 @@ func (c *Client) GetRTPStream(id int64) (*RTPStream, error) {
 	return &target["test"][0], nil
 }
 
-//CreateRTPStream - Create voice call test
+// CreateRTPStream - Create voice call test
 func (c Client) CreateRTPStream(t RTPStream) (*RTPStream, error) {
 	resp, err := c.post("/tests/voice/new", t, nil)
 	if err != nil {
@@ -110,7 +110,7 @@ func (c Client) CreateRTPStream(t RTPStream) (*RTPStream, error) {
 	return &target["test"][0], nil
 }
 
-//DeleteRTPStream - delete voice call test
+// DeleteRTPStream - delete voice call test
 func (c *Client) DeleteRTPStream(id int64) error {
 	resp, err := c.post(fmt.Sprintf("/tests/voice/%d/delete", id), nil, nil)
 	if err != nil {
@@ -122,7 +122,7 @@ func (c *Client) DeleteRTPStream(id int64) error {
 	return nil
 }
 
-//UpdateRTPStream - update voice call test
+// UpdateRTPStream - update voice call test
 func (c *Client) UpdateRTPStream(id int64, t RTPStream) (*RTPStream, error) {
 	resp, err := c.post(fmt.Sprintf("/tests/voice/%d/update", id), t, nil)
 	if err != nil {

--- a/web_transaction.go
+++ b/web_transaction.go
@@ -102,7 +102,7 @@ func (c Client) CreateWebTransaction(t WebTransaction) (*WebTransaction, error) 
 	return &target["test"][0], nil
 }
 
-//GetWebTransaction - get a web transactiont test
+// GetWebTransaction - get a web transactiont test
 func (c *Client) GetWebTransaction(id int64) (*WebTransaction, error) {
 	resp, err := c.get(fmt.Sprintf("/tests/%d", id))
 	if err != nil {
@@ -115,7 +115,7 @@ func (c *Client) GetWebTransaction(id int64) (*WebTransaction, error) {
 	return &target["test"][0], nil
 }
 
-//DeleteWebTransaction - delete a web transactiont est
+// DeleteWebTransaction - delete a web transactiont est
 func (c *Client) DeleteWebTransaction(id int64) error {
 	resp, err := c.post(fmt.Sprintf("/tests/web-transactions/%d/delete", id), nil, nil)
 	if err != nil {


### PR DESCRIPTION
  * Also fixes one of the unit tests which was actually not running
  * I ran `go fmt` which is what fixed the spacing in those comments

This is useful to allow us to use terraform with our staging environments. 

Tests are clean:
```
go vet ./... && echo && go test ./...

ok  	github.com/thousandeyes/thousandeyes-sdk-go/v2	1.386s
```

Tested locally without overriding:
```
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - thousandeyes/thousandeyes in /Users/pedrorg/go/bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
thousandeyes_alert_rule.test_alert_rule: Refreshing state... [id=4946549]
thousandeyes_agent_to_server.thousandeyes_agent_to_server_tcp_no_port: Refreshing state... [id=3113616]
thousandeyes_dns_server.example_dns_server_test: Refreshing state... [id=3027162]
thousandeyes_agent_to_agent.example_agent_to_agent: Refreshing state... [id=3026866]
thousandeyes_label.tf: Refreshing state... [id=410351]
thousandeyes_alert_rule.thousandeyes_alert_rule_slack: Refreshing state... [id=5009877]
thousandeyes_sip_server.sip_server_example: Refreshing state... [id=3026862]
thousandeyes_agent_to_server.thousandeyes_agent_to_server_icmp_test: Refreshing state... [id=3113617]
thousandeyes_agent_to_server.google_agent_to_server: Refreshing state... [id=3026865]
thousandeyes_alert_rule.test_alert_rule-2: Refreshing state... [id=4946550]
thousandeyes_voice.webex_rtp_example: Refreshing state... [id=3026905]
thousandeyes_page_load.test: Refreshing state... [id=3026863]
thousandeyes_http_server.www_thousandeyes_http_test: Refreshing state... [id=3026864]

No changes. Your infrastructure matches the configuration.
```

And with overrides (of course it fails):
```
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - thousandeyes/thousandeyes in /Users/pedrorg/go/bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
thousandeyes_alert_rule.test_alert_rule: Refreshing state... [id=4946549]
thousandeyes_agent_to_server.thousandeyes_agent_to_server_tcp_no_port: Refreshing state... [id=3113616]
thousandeyes_agent_to_server.thousandeyes_agent_to_server_icmp_test: Refreshing state... [id=3113617]
thousandeyes_agent_to_server.google_agent_to_server: Refreshing state... [id=3026865]
thousandeyes_label.tf: Refreshing state... [id=410351]
thousandeyes_dns_server.example_dns_server_test: Refreshing state... [id=3027162]
thousandeyes_agent_to_agent.example_agent_to_agent: Refreshing state... [id=3026866]
thousandeyes_sip_server.sip_server_example: Refreshing state... [id=3026862]
thousandeyes_alert_rule.test_alert_rule-2: Refreshing state... [id=4946550]
thousandeyes_alert_rule.thousandeyes_alert_rule_slack: Refreshing state... [id=5009877]
╷
│ Error: Get "https://api.millioneyes.com/v9/agents.json?aid=69": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
│
│   with data.thousandeyes_agent.arg_cordoba,
│   on main.tf line 1, in data "thousandeyes_agent" "arg_cordoba":
│    1: data "thousandeyes_agent" "arg_cordoba" {
│
╵
╷
│ Error: Get "https://api.millioneyes.com/v9/agents.json?aid=69": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
│
│   with data.thousandeyes_agent.arg_bsas,
│   on main.tf line 5, in data "thousandeyes_agent" "arg_bsas":
│    5: data "thousandeyes_agent" "arg_bsas" {
```