### PR TITLE
fix: ensures an empty array is marshalled rather than null in labels

### DIFF
--- a/group_label.go
+++ b/group_label.go
@@ -24,6 +24,16 @@ type GroupLabel struct {
 func (t GroupLabel) MarshalJSON() ([]byte, error) {
 	type alias GroupLabel
 
+	if t.Tests != nil && len(*t.Tests) == 0 {
+		ts := make([]GenericTest, 0)
+		t.Tests = &ts
+	}
+
+	if t.Agents != nil && len(*t.Agents) == 0 {
+		as := make([]Agent, 0)
+		t.Agents = &as
+	}
+
 	data, err := json.Marshal((alias)(t))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
When all agents or tests were removed from a label/group the client was marshalling the absence of those fields to null. The ThousandEyes API ignored the null value and didn't actually make any changes to the label/group. But from terraform's perspective the agents/tests had been removed (from the state). By passing an empty array, the ThousandEyes API removes the agents/tests sucessfully from the label.

Before change with debug logging enabled:
```
thousandeyes_label.pedro-label-agents: Modifying... [id=X]
2023-01-16T18:31:49.816Z [INFO]  Starting apply for thousandeyes_label.pedro-label-agents
2023-01-16T18:31:49.817Z [INFO]  provider.terraform-provider-thousandeyes: 2023/01/16 18:31:49 [INFO] Updating ThousandEyes Label 582876: timestamp=2023-01-16T18:31:49.817Z
2023-01-16T18:31:49.818Z [INFO]  provider.terraform-provider-thousandeyes: 2023/01/16 18:31:49 GROUP LABEL UPDATE:
 {"agents":null,"name":"Pedro - Test Agent Label"}: timestamp=2023-01-16T18:31:49.818Z
```

After change with debug logging enabled:
```
thousandeyes_label.pedro-label-agents: Modifying... [id=X]
2023-01-16T18:47:12.367Z [INFO]  Starting apply for thousandeyes_label.pedro-label-agents
2023-01-16T18:47:12.368Z [INFO]  provider.terraform-provider-thousandeyes: 2023/01/16 18:47:12 [INFO] Updating ThousandEyes Label 582876: timestamp=2023-01-16T18:47:12.368Z
2023-01-16T18:47:12.368Z [INFO]  provider.terraform-provider-thousandeyes: 2023/01/16 18:47:12 GROUP LABEL UPDATE:
 {"agents":[],"name":"Pedro - Test Agent Label"}: timestamp=2023-01-16T18:47:12.368Z
```