### PR TITLE
feat: add severity property to alert rule

### DIFF
--- a/alerts.go
+++ b/alerts.go
@@ -72,6 +72,7 @@ type AlertRule struct {
 	RuleName                *string       `json:"ruleName,omitempty"`
 	TestIds                 *[]int        `json:"testIds,omitempty"`
 	Notifications           *Notification `json:"notifications,omitempty"`
+	Severity                *string       `json:"severity,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaler interface. It ensures


### PR DESCRIPTION
Seems like this change was [previously made](https://github.com/thousandeyes/thousandeyes-sdk-go/pull/114) but was never merged into the main branch, so I'm creating it again.