### PR TITLE
fix: change DownloadLimit to correct type (int)

### DIFF
--- a/http_server.go
+++ b/http_server.go
@@ -48,7 +48,7 @@ type HTTPServer struct {
 	ContentRegex          *string        `json:"contentRegex,omitempty"`
 	CustomHeaders         *CustomHeaders `json:"customHeaders,omitempty"`
 	DesiredStatusCode     *string        `json:"desiredStatusCode,omitempty"`
-	DownloadLimit         *string        `json:"downloadLimit,omitempty"`
+	DownloadLimit         *int           `json:"downloadLimit,omitempty"`
 	DNSOverride           *string        `json:"dnsOverride,omitempty"`
 	FollowRedirects       *bool          `json:"followRedirects,omitempty" te:"int-bool"`
 	Headers               *[]string      `json:"headers,omitempty"`


### PR DESCRIPTION
HTTP Server test attribute DownloadLimit was set to string, it should be int.

Fixes #82 