### PR TITLE
Adding notification webhook structure

### DIFF
--- a/alert_test.go
+++ b/alert_test.go
@@ -147,6 +147,58 @@ func TestClient_CreateAlertRuleWithNotifications(t *testing.T) {
 	assert.Equal(t, &expected, res)
 }
 
+func TestClient_CreateAlertRuleWithWebhookNotifications(t *testing.T) {
+	setup()
+	out := `{"alertRuleId": 1, "ruleName": "test", "notifications":{"webhook":[{"integrationId": "1", "integrationName": "foo", "integrationType":"bar"},{"integrationId": "2", "integrationName": "foo2", "integrationType":"bar2"}]}}`
+	mux.HandleFunc("/alert-rules/new.json", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(out))
+	})
+
+	var client = &Client{APIEndpoint: server.URL, AuthToken: "foo"}
+	u := AlertRule{
+		RuleName: String("test"),
+		Notifications: &Notification{
+			Webhook: &[]NotificationWebhook{
+				{
+					IntegrationID:   String("1"),
+					IntegrationName: String("foo"),
+					IntegrationType: String("bar"),
+				},
+				{
+					IntegrationID:   String("2"),
+					IntegrationName: String("foo2"),
+					IntegrationType: String("bar2"),
+				},
+			},
+		},
+	}
+	res, err := client.CreateAlertRule(u)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := AlertRule{
+		RuleID:   Int64(1),
+		RuleName: String("test"),
+		Notifications: &Notification{
+			Webhook: &[]NotificationWebhook{
+				{
+					IntegrationID:   String("1"),
+					IntegrationName: String("foo"),
+					IntegrationType: String("bar"),
+				},
+				{
+					IntegrationID:   String("2"),
+					IntegrationName: String("foo2"),
+					IntegrationType: String("bar2"),
+				},
+			},
+		},
+	}
+	assert.Equal(t, &expected, res)
+}
+
 func TestClient_AlertJsonError(t *testing.T) {
 	out := `{"alertRules": [test]}`
 	setup()

--- a/alert_test.go
+++ b/alert_test.go
@@ -149,7 +149,7 @@ func TestClient_CreateAlertRuleWithNotifications(t *testing.T) {
 
 func TestClient_CreateAlertRuleWithWebhookNotifications(t *testing.T) {
 	setup()
-	out := `{"alertRuleId": 1, "ruleName": "test", "notifications":{"webhook":[{"integrationId": "1", "integrationName": "foo", "integrationType":"bar"},{"integrationId": "2", "integrationName": "foo2", "integrationType":"bar2"}]}}`
+	out := `{"alertRuleId": 1, "ruleName": "test", "notifications":{"webhook":[{"integrationId": "1", "integrationName": "Teams Channel", "integrationType":"WEBHOOK"},{"integrationId": "2", "integrationName": "Teams Channel", "integrationType":"WEBHOOK"}]}}`
 	mux.HandleFunc("/alert-rules/new.json", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "POST", r.Method)
 		w.WriteHeader(http.StatusCreated)
@@ -163,13 +163,13 @@ func TestClient_CreateAlertRuleWithWebhookNotifications(t *testing.T) {
 			Webhook: &[]NotificationWebhook{
 				{
 					IntegrationID:   String("1"),
-					IntegrationName: String("foo"),
-					IntegrationType: String("bar"),
+					IntegrationName: String("Teams Channel"),
+					IntegrationType: String("WEBHOOK"),
 				},
 				{
 					IntegrationID:   String("2"),
-					IntegrationName: String("foo2"),
-					IntegrationType: String("bar2"),
+					IntegrationName: String("Teams Channel"),
+					IntegrationType: String("WEBHOOK"),
 				},
 			},
 		},
@@ -185,13 +185,13 @@ func TestClient_CreateAlertRuleWithWebhookNotifications(t *testing.T) {
 			Webhook: &[]NotificationWebhook{
 				{
 					IntegrationID:   String("1"),
-					IntegrationName: String("foo"),
-					IntegrationType: String("bar"),
+					IntegrationName: String("Teams Channel"),
+					IntegrationType: String("WEBHOOK"),
 				},
 				{
 					IntegrationID:   String("2"),
-					IntegrationName: String("foo2"),
-					IntegrationType: String("bar2"),
+					IntegrationName: String("Teams Channel"),
+					IntegrationType: String("WEBHOOK"),
 				},
 			},
 		},

--- a/alerts.go
+++ b/alerts.go
@@ -48,10 +48,19 @@ type NotificationThirdParty struct {
 	Channel         *string `json:"channel,omitempty"`
 }
 
+// NotificationWebhook - Alert Rule Notification Webhook structure
+type NotificationWebhook struct {
+	IntegrationID   *string `json:"integrationId,omitempty"`
+	IntegrationName *string `json:"integrationName,omitempty"`
+	IntegrationType *string `json:"integrationType,omitempty"`
+	Target          *string `json:"target,omitempty"`
+}
+
 // Notification - Alert Rule Notification structure
 type Notification struct {
 	Email      *NotificationEmail        `json:"email,omitempty"`
 	ThirdParty *[]NotificationThirdParty `json:"thirdParty,omitempty"`
+	Webhook    *[]NotificationWebhook    `json:"webhook,omitempty"`
 }
 
 // AlertRule - An alert rule


### PR DESCRIPTION
This aims to ultimately support using webhooks for integrations within the ThousandEyes terraform provider. 

Currently, if you create a custom webhook integration (for example, Microsoft Teams), you can't use it to create/update alert rules with webhook notifications (using an integration data source in terraform).

I think there just needs to be an additional struct, if this is wrong please let me know. 

Any feedback would be appreciated!

