### PR TITLE
doc: Add Support-related documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ func main() {
 
 ## Support
 
+Join the discussion in the [ThousandEyes Community](https://community.cisco.com/t5/thousandeyes/bd-p/disc-thousandeyes).
 For bug reports, feature requests, or questions about this SDK, please contact [ThousandEyes Support](https://docs.thousandeyes.com/product-documentation/getting-started/getting-support-from-thousandeyes#contacting-support).
 
 ## Contributing


### PR DESCRIPTION
### What changed and why
Updated the README Support section to point users to the ThousandEyes Community and the official ThousandEyes Support page.

### Architecture Diagram
Documentation-only change.

# Checklist:

- [x] Self-review of my own code
- [x] Documentation (SwaggerHub, README, Confluence)
- [ ] Test
- [x] Observability: not applicable for this documentation-only change
- [x] Code style
- [x] Clean code