### PR TITLE
CP-4595 fix nullable bool constructors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,4 +20,4 @@ jobs:
           ~/go/bin/golint -set_exit_status
 
       - name: Test
-        run: go test -race -coverprofile=coverage.txt -covermode=atomic
+        run: go test -race -coverprofile=coverage.txt -covermode=atomic ./...

--- a/dashboards/model_api_pie_chart_widget.go
+++ b/dashboards/model_api_pie_chart_widget.go
@@ -61,7 +61,7 @@ func NewApiPieChartWidget(type_ string) *ApiPieChartWidget {
 	this.VisualMode = &visualMode
 	this.Type = type_
 	var showSubmetrics bool = true
-	this.ShowSubmetrics = *NewNullableBool(&showSubmetrics)
+	this.ShowSubmetrics = *utils.NewNullableBool(&showSubmetrics)
 	return &this
 }
 
@@ -73,7 +73,7 @@ func NewApiPieChartWidgetWithDefaults() *ApiPieChartWidget {
 	var visualMode VisualMode = "Full"
 	this.VisualMode = &visualMode
 	var showSubmetrics bool = true
-	this.ShowSubmetrics = *NewNullableBool(&showSubmetrics)
+	this.ShowSubmetrics = *utils.NewNullableBool(&showSubmetrics)
 	return &this
 }
 

--- a/dashboards/model_api_pie_chart_widget_properties.go
+++ b/dashboards/model_api_pie_chart_widget_properties.go
@@ -38,7 +38,7 @@ func NewApiPieChartWidgetProperties(type_ string) *ApiPieChartWidgetProperties {
 	this := ApiPieChartWidgetProperties{}
 	this.Type = type_
 	var showSubmetrics bool = true
-	this.ShowSubmetrics = *NewNullableBool(&showSubmetrics)
+	this.ShowSubmetrics = *utils.NewNullableBool(&showSubmetrics)
 	return &this
 }
 
@@ -48,7 +48,7 @@ func NewApiPieChartWidgetProperties(type_ string) *ApiPieChartWidgetProperties {
 func NewApiPieChartWidgetPropertiesWithDefaults() *ApiPieChartWidgetProperties {
 	this := ApiPieChartWidgetProperties{}
 	var showSubmetrics bool = true
-	this.ShowSubmetrics = *NewNullableBool(&showSubmetrics)
+	this.ShowSubmetrics = *utils.NewNullableBool(&showSubmetrics)
 	return &this
 }
 

--- a/dashboards/model_api_stacked_area_chart_widget.go
+++ b/dashboards/model_api_stacked_area_chart_widget.go
@@ -66,7 +66,7 @@ func NewApiStackedAreaChartWidget(type_ string) *ApiStackedAreaChartWidget {
 	this.VisualMode = &visualMode
 	this.Type = type_
 	var showSubmetrics bool = true
-	this.ShowSubmetrics = *NewNullableBool(&showSubmetrics)
+	this.ShowSubmetrics = *utils.NewNullableBool(&showSubmetrics)
 	return &this
 }
 
@@ -78,7 +78,7 @@ func NewApiStackedAreaChartWidgetWithDefaults() *ApiStackedAreaChartWidget {
 	var visualMode VisualMode = "Full"
 	this.VisualMode = &visualMode
 	var showSubmetrics bool = true
-	this.ShowSubmetrics = *NewNullableBool(&showSubmetrics)
+	this.ShowSubmetrics = *utils.NewNullableBool(&showSubmetrics)
 	return &this
 }
 

--- a/dashboards/model_api_stacked_area_chart_widget_properties.go
+++ b/dashboards/model_api_stacked_area_chart_widget_properties.go
@@ -38,7 +38,7 @@ func NewApiStackedAreaChartWidgetProperties(type_ string) *ApiStackedAreaChartWi
 	this := ApiStackedAreaChartWidgetProperties{}
 	this.Type = type_
 	var showSubmetrics bool = true
-	this.ShowSubmetrics = *NewNullableBool(&showSubmetrics)
+	this.ShowSubmetrics = *utils.NewNullableBool(&showSubmetrics)
 	return &this
 }
 
@@ -48,7 +48,7 @@ func NewApiStackedAreaChartWidgetProperties(type_ string) *ApiStackedAreaChartWi
 func NewApiStackedAreaChartWidgetPropertiesWithDefaults() *ApiStackedAreaChartWidgetProperties {
 	this := ApiStackedAreaChartWidgetProperties{}
 	var showSubmetrics bool = true
-	this.ShowSubmetrics = *NewNullableBool(&showSubmetrics)
+	this.ShowSubmetrics = *utils.NewNullableBool(&showSubmetrics)
 	return &this
 }
 


### PR DESCRIPTION
## Summary

- Regenerate the v3 Go SDK from ThousandEyes API specs `7.0.92` using generator commit `70b9dac7dba93e5ce338329bec8c983303b77604`.
- Keep the generated delta limited to the nullable bool constructor fix in the dashboard package.
- Update the test workflow so CI runs `go test` across all packages with `./...`.

## Context

This excludes the later generator/spec sync commit `682499de1d4e1d28b992f22a48b27aed576b8996`, which moves specs to `7.0.93`, so the PR only carries the SDK compile fix and CI coverage fix.

The CI change addresses why PR #194 did not catch the dashboard package compilation issue: the workflow only tested the root package before this change.

## Testing

- `mise exec -- ./gradlew -PmavenCentralOnly=true generateGoSdk`
- `go test ./...`
- `go test -race -coverprofile=coverage.txt -covermode=atomic ./...`
- `git diff --check`

Independent review also reran:

- `git diff --check origin/v3...HEAD`
- `go test ./...`
- `go test -race -coverprofile=/private/tmp/cp4595-thousandeyes-sdk-go-coverage.txt -covermode=atomic ./...`