### PR TITLE
feature: add core client runtime unit tests

### DIFF
--- a/client/backoffs.go
+++ b/client/backoffs.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"math"
 	"net/http"
 	"regexp"
 	"strconv"
@@ -35,14 +36,13 @@ func thousandEyesBackoff(min, max time.Duration, attemptNum int, resp *http.Resp
 			if sleep, ok := parseResetHeader(&resetTimeStr); ok {
 				return sleep
 			}
-
-			// Default backoff if no valid reset time is found
-			return retryablehttp.DefaultBackoff(min, max, attemptNum, resp)
 		}
 	}
 
 	// Default case for no Retry-After and rateLimitResetHeaders
-	return retryablehttp.DefaultBackoff(min, max, attemptNum, resp)
+	// Retry-After has already been validated above. Do not pass the response to
+	// DefaultBackoff, which would parse an invalid header again.
+	return retryablehttp.DefaultBackoff(min, max, attemptNum, nil)
 }
 
 func parseRetryAfterHeader(headers []string) (time.Duration, bool) {
@@ -52,14 +52,14 @@ func parseRetryAfterHeader(headers []string) (time.Duration, bool) {
 	header := headers[0]
 	// Retry-After: 120
 	if sleep, err := strconv.ParseInt(header, 10, 64); err == nil {
-		if sleep < 0 { // a negative sleep doesn't make sense
+		if sleep < 0 || sleep > math.MaxInt64/int64(time.Second) {
 			return 0, false
 		}
 		return time.Second * time.Duration(sleep), true
 	}
 
 	// Retry-After: Fri, 31 Dec 1999 23:59:59 GMT
-	retryTime, err := time.Parse(time.RFC1123, header)
+	retryTime, err := http.ParseTime(header)
 	if err != nil {
 		return 0, false
 	}
@@ -84,7 +84,7 @@ func parseResetHeader(value *string) (time.Duration, bool) {
 
 	// Calculate the duration until the reset time
 	resetTime := time.Unix(resetTimeUnix, 0)
-	waitDuration := time.Until(resetTime)
+	waitDuration := resetTime.Sub(timeNow())
 
 	// Return 0 if the reset time has already passed
 	if waitDuration < 0 {

--- a/client/backoffs_test.go
+++ b/client/backoffs_test.go
@@ -1,0 +1,235 @@
+package client
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func useFixedTime(t *testing.T, now time.Time) {
+	t.Helper()
+
+	original := timeNow
+	timeNow = func() time.Time { return now }
+	t.Cleanup(func() {
+		timeNow = original
+	})
+}
+
+func TestParseRetryAfterHeader(t *testing.T) {
+	now := time.Date(2026, time.July, 24, 12, 0, 0, 0, time.UTC)
+	useFixedTime(t, now)
+
+	tests := []struct {
+		name    string
+		headers []string
+		want    time.Duration
+		wantOK  bool
+	}{
+		{name: "missing", wantOK: false},
+		{name: "empty", headers: []string{""}, wantOK: false},
+		{name: "seconds", headers: []string{"120"}, want: 120 * time.Second, wantOK: true},
+		{name: "zero seconds", headers: []string{"0"}, wantOK: true},
+		{name: "negative seconds", headers: []string{"-1"}, wantOK: false},
+		{name: "overflow seconds", headers: []string{"9999999999"}, wantOK: false},
+		{name: "invalid", headers: []string{"later"}, wantOK: false},
+		{
+			name:    "IMF-fixdate",
+			headers: []string{now.Add(2 * time.Minute).Format(http.TimeFormat)},
+			want:    2 * time.Minute,
+			wantOK:  true,
+		},
+		{
+			name:    "RFC850",
+			headers: []string{now.Add(2 * time.Minute).Format(time.RFC850)},
+			want:    2 * time.Minute,
+			wantOK:  true,
+		},
+		{
+			name:    "ANSI C asctime",
+			headers: []string{now.Add(2 * time.Minute).Format(time.ANSIC)},
+			want:    2 * time.Minute,
+			wantOK:  true,
+		},
+		{
+			name:    "past date",
+			headers: []string{now.Add(-time.Minute).Format(http.TimeFormat)},
+			wantOK:  true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, ok := parseRetryAfterHeader(test.headers)
+			if ok != test.wantOK {
+				t.Fatalf("parseRetryAfterHeader() ok = %v, want %v", ok, test.wantOK)
+			}
+			if got != test.want {
+				t.Fatalf("parseRetryAfterHeader() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestParseResetHeader(t *testing.T) {
+	now := time.Unix(1_800_000_000, 0)
+	useFixedTime(t, now)
+
+	future := "1800000120"
+	past := "1799999940"
+	whitespace := " 1800000120 "
+	invalid := "not-a-timestamp"
+	overflow := "999999999999999999999999"
+
+	tests := []struct {
+		name   string
+		value  *string
+		want   time.Duration
+		wantOK bool
+	}{
+		{name: "nil", wantOK: false},
+		{name: "future", value: &future, want: 2 * time.Minute, wantOK: true},
+		{name: "past", value: &past, wantOK: true},
+		{name: "surrounding whitespace", value: &whitespace, wantOK: false},
+		{name: "invalid", value: &invalid, wantOK: false},
+		{name: "overflow", value: &overflow, wantOK: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, ok := parseResetHeader(test.value)
+			if ok != test.wantOK {
+				t.Fatalf("parseResetHeader() ok = %v, want %v", ok, test.wantOK)
+			}
+			if got != test.want {
+				t.Fatalf("parseResetHeader() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestThousandEyesBackoff(t *testing.T) {
+	now := time.Unix(1_800_000_000, 0)
+	useFixedTime(t, now)
+
+	const (
+		min     = time.Second
+		max     = 30 * time.Second
+		attempt = 2
+	)
+	futureOrganization := "1800000120"
+	futureInstant := "1800000060"
+	past := "1799999940"
+
+	response := func(status int, headers map[string]string) *http.Response {
+		header := make(http.Header)
+		for name, value := range headers {
+			header.Set(name, value)
+		}
+		return &http.Response{StatusCode: status, Header: header}
+	}
+
+	tests := []struct {
+		name string
+		resp *http.Response
+		want time.Duration
+	}{
+		{name: "nil response", want: 0},
+		{
+			name: "Retry-After seconds on 429",
+			resp: response(http.StatusTooManyRequests, map[string]string{"Retry-After": "10"}),
+			want: 10 * time.Second,
+		},
+		{
+			name: "Retry-After seconds on 503",
+			resp: response(http.StatusServiceUnavailable, map[string]string{"Retry-After": "10"}),
+			want: 10 * time.Second,
+		},
+		{
+			name: "Retry-After HTTP-date",
+			resp: response(http.StatusTooManyRequests, map[string]string{
+				"Retry-After": now.Add(90 * time.Second).Format(http.TimeFormat),
+			}),
+			want: 90 * time.Second,
+		},
+		{
+			name: "Retry-After ignored for other status",
+			resp: response(http.StatusOK, map[string]string{"Retry-After": "10"}),
+			want: 4 * time.Second,
+		},
+		{
+			name: "Retry-After precedes reset headers",
+			resp: response(http.StatusTooManyRequests, map[string]string{
+				"Retry-After":                     "10",
+				"x-organization-rate-limit-reset": futureOrganization,
+			}),
+			want: 10 * time.Second,
+		},
+		{
+			name: "organization reset precedes instant-test reset",
+			resp: response(http.StatusTooManyRequests, map[string]string{
+				"x-organization-rate-limit-reset": futureOrganization,
+				"x-instant-test-rate-limit-reset": futureInstant,
+			}),
+			want: 2 * time.Minute,
+		},
+		{
+			name: "invalid organization reset falls through to instant-test reset",
+			resp: response(http.StatusTooManyRequests, map[string]string{
+				"x-organization-rate-limit-reset": "invalid",
+				"x-instant-test-rate-limit-reset": futureInstant,
+			}),
+			want: time.Minute,
+		},
+		{
+			name: "invalid Retry-After falls through to reset header",
+			resp: response(http.StatusTooManyRequests, map[string]string{
+				"Retry-After":                     "invalid",
+				"x-organization-rate-limit-reset": futureOrganization,
+			}),
+			want: 2 * time.Minute,
+		},
+		{
+			name: "overflowing Retry-After falls through to reset header",
+			resp: response(http.StatusTooManyRequests, map[string]string{
+				"Retry-After":                     "9999999999",
+				"x-organization-rate-limit-reset": futureOrganization,
+			}),
+			want: 2 * time.Minute,
+		},
+		{
+			name: "overflowing Retry-After without reset falls back",
+			resp: response(http.StatusTooManyRequests, map[string]string{
+				"Retry-After": "9999999999",
+			}),
+			want: 4 * time.Second,
+		},
+		{
+			name: "past reset returns zero",
+			resp: response(http.StatusTooManyRequests, map[string]string{
+				"x-organization-rate-limit-reset": past,
+			}),
+			want: 0,
+		},
+		{
+			name: "invalid reset falls back",
+			resp: response(http.StatusTooManyRequests, map[string]string{
+				"x-organization-rate-limit-reset": "invalid",
+			}),
+			want: 4 * time.Second,
+		},
+		{
+			name: "missing headers falls back",
+			resp: response(http.StatusTooManyRequests, nil),
+			want: 4 * time.Second,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := thousandEyesBackoff(min, max, attempt, test.resp); got != test.want {
+				t.Fatalf("thousandEyesBackoff() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}

--- a/client/client.go
+++ b/client/client.go
@@ -186,30 +186,6 @@ func (c *APIClient) Decode(v interface{}, b []byte, contentType string) (err err
 		*s = string(b)
 		return nil
 	}
-	if f, ok := v.(*os.File); ok {
-		f, err = os.CreateTemp("", "HttpClientFile")
-		if err != nil {
-			return
-		}
-		_, err = f.Write(b)
-		if err != nil {
-			return
-		}
-		_, err = f.Seek(0, io.SeekStart)
-		return
-	}
-	if f, ok := v.(**os.File); ok {
-		*f, err = os.CreateTemp("", "HttpClientFile")
-		if err != nil {
-			return
-		}
-		_, err = (*f).Write(b)
-		if err != nil {
-			return
-		}
-		_, err = (*f).Seek(0, io.SeekStart)
-		return
-	}
 	if JsonCheck.MatchString(contentType) {
 		if actualObj, ok := v.(interface{ GetActualInstance() interface{} }); ok { // oneOf, anyOf schemas
 			if unmarshalObj, ok := actualObj.(interface{ UnmarshalJSON([]byte) error }); ok { // make sure it has UnmarshalJSON defined

--- a/client/client.go
+++ b/client/client.go
@@ -186,6 +186,30 @@ func (c *APIClient) Decode(v interface{}, b []byte, contentType string) (err err
 		*s = string(b)
 		return nil
 	}
+	if f, ok := v.(*os.File); ok {
+		f, err = os.CreateTemp("", "HttpClientFile")
+		if err != nil {
+			return
+		}
+		_, err = f.Write(b)
+		if err != nil {
+			return
+		}
+		_, err = f.Seek(0, io.SeekStart)
+		return
+	}
+	if f, ok := v.(**os.File); ok {
+		*f, err = os.CreateTemp("", "HttpClientFile")
+		if err != nil {
+			return
+		}
+		_, err = (*f).Write(b)
+		if err != nil {
+			return
+		}
+		_, err = (*f).Seek(0, io.SeekStart)
+		return
+	}
 	if JsonCheck.MatchString(contentType) {
 		if actualObj, ok := v.(interface{ GetActualInstance() interface{} }); ok { // oneOf, anyOf schemas
 			if unmarshalObj, ok := actualObj.(interface{ UnmarshalJSON([]byte) error }); ok { // make sure it has UnmarshalJSON defined

--- a/client/client.go
+++ b/client/client.go
@@ -186,29 +186,29 @@ func (c *APIClient) Decode(v interface{}, b []byte, contentType string) (err err
 		*s = string(b)
 		return nil
 	}
-	if f, ok := v.(*os.File); ok {
-		f, err = os.CreateTemp("", "HttpClientFile")
+	if destination, ok := v.(**os.File); ok {
+		decodedFile, err := os.CreateTemp("", "HttpClientFile")
 		if err != nil {
-			return
+			return err
 		}
-		_, err = f.Write(b)
+
+		cleanup := func() {
+			_ = decodedFile.Close()
+			_ = os.Remove(decodedFile.Name())
+		}
+
+		_, err = decodedFile.Write(b)
 		if err != nil {
-			return
+			cleanup()
+			return err
 		}
-		_, err = f.Seek(0, io.SeekStart)
-		return
-	}
-	if f, ok := v.(**os.File); ok {
-		*f, err = os.CreateTemp("", "HttpClientFile")
-		if err != nil {
-			return
+		if _, err = decodedFile.Seek(0, io.SeekStart); err != nil {
+			cleanup()
+			return err
 		}
-		_, err = (*f).Write(b)
-		if err != nil {
-			return
-		}
-		_, err = (*f).Seek(0, io.SeekStart)
-		return
+
+		*destination = decodedFile
+		return nil
 	}
 	if JsonCheck.MatchString(contentType) {
 		if actualObj, ok := v.(interface{ GetActualInstance() interface{} }); ok { // oneOf, anyOf schemas

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,0 +1,265 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+)
+
+type contextKey struct{}
+
+func newRequestTestClient(cfg *Configuration) *APIClient {
+	return &APIClient{cfg: cfg}
+}
+
+func TestPrepareRequestHeadersQueryAndContext(t *testing.T) {
+	baseCtx, cancel := context.WithCancel(context.Background())
+	ctx := context.WithValue(baseCtx, contextKey{}, "context-value")
+	cancel()
+	cfg := NewConfiguration().WithAuthToken("synthetic-token")
+	cfg.UserAgent = "test-suite/1.0"
+	cfg.Context = ctx
+	apiClient := newRequestTestClient(cfg)
+
+	query := url.Values{
+		"filter[name]": {"first", "second"},
+		"new":          {"value"},
+	}
+	request, err := apiClient.PrepareRequest(
+		"https://example.test/resource?existing=preserved",
+		http.MethodGet,
+		nil,
+		map[string]string{"X-Test": "header"},
+		query,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("PrepareRequest() error = %v", err)
+	}
+
+	if got := request.Header.Get("Authorization"); got != "Bearer synthetic-token" {
+		t.Fatalf("Authorization = %q, want %q", got, "Bearer synthetic-token")
+	}
+	wantUserAgent := "ThousandEyesSDK-Go/" + SDKVersion() + " test-suite/1.0"
+	if got := request.Header.Get("User-Agent"); got != wantUserAgent {
+		t.Fatalf("User-Agent = %q, want %q", got, wantUserAgent)
+	}
+	if got := request.Header.Get("X-Test"); got != "header" {
+		t.Fatalf("X-Test = %q, want %q", got, "header")
+	}
+	if got := request.URL.Query().Get("existing"); got != "preserved" {
+		t.Fatalf("existing query = %q, want %q", got, "preserved")
+	}
+	if got := request.URL.Query()["filter[name]"]; len(got) != 2 || got[0] != "first" || got[1] != "second" {
+		t.Fatalf("filter[name] query = %#v, want [first second]", got)
+	}
+	if !strings.Contains(request.URL.RawQuery, "filter[name]=") {
+		t.Fatalf("RawQuery = %q, want unescaped bracketed key", request.URL.RawQuery)
+	}
+	if got := request.Context().Value(contextKey{}); got != "context-value" {
+		t.Fatalf("request context value = %v, want %q", got, "context-value")
+	}
+	if err := request.Context().Err(); err != context.Canceled {
+		t.Fatalf("request context error = %v, want %v", err, context.Canceled)
+	}
+}
+
+func TestPrepareRequestOmitsAuthorizationWithoutToken(t *testing.T) {
+	request, err := newRequestTestClient(NewConfiguration()).PrepareRequest(
+		"https://example.test/resource",
+		http.MethodGet,
+		nil,
+		map[string]string{},
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("PrepareRequest() error = %v", err)
+	}
+	if got := request.Header.Get("Authorization"); got != "" {
+		t.Fatalf("Authorization = %q, want empty", got)
+	}
+}
+
+func TestPrepareRequestJSONBody(t *testing.T) {
+	headers := map[string]string{}
+	request, err := newRequestTestClient(NewConfiguration()).PrepareRequest(
+		"https://example.test/resource",
+		http.MethodPost,
+		map[string]string{"name": "example"},
+		headers,
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("PrepareRequest() error = %v", err)
+	}
+
+	if got := request.Header.Get("Content-Type"); got != "application/json; charset=utf-8" {
+		t.Fatalf("Content-Type = %q, want JSON", got)
+	}
+	var body map[string]string
+	if err := json.NewDecoder(request.Body).Decode(&body); err != nil {
+		t.Fatalf("decoding request body: %v", err)
+	}
+	if got := body["name"]; got != "example" {
+		t.Fatalf("body name = %q, want %q", got, "example")
+	}
+}
+
+func TestPrepareRequestFormBody(t *testing.T) {
+	form := url.Values{"name": {"example"}, "tag": {"one", "two"}}
+	request, err := newRequestTestClient(NewConfiguration()).PrepareRequest(
+		"https://example.test/resource",
+		http.MethodPost,
+		nil,
+		map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
+		nil,
+		form,
+	)
+	if err != nil {
+		t.Fatalf("PrepareRequest() error = %v", err)
+	}
+
+	body, err := io.ReadAll(request.Body)
+	if err != nil {
+		t.Fatalf("reading request body: %v", err)
+	}
+	if got, want := string(body), form.Encode(); got != want {
+		t.Fatalf("form body = %q, want %q", got, want)
+	}
+	if got, want := request.Header.Get("Content-Length"), "28"; got != want {
+		t.Fatalf("Content-Length = %q, want %q", got, want)
+	}
+}
+
+func TestPrepareRequestFailures(t *testing.T) {
+	apiClient := newRequestTestClient(NewConfiguration())
+
+	tests := []struct {
+		name        string
+		path        string
+		method      string
+		postBody    interface{}
+		headers     map[string]string
+		form        url.Values
+		wantMessage string
+	}{
+		{
+			name:        "body and form conflict",
+			path:        "https://example.test/resource",
+			method:      http.MethodPost,
+			postBody:    "body",
+			headers:     map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
+			form:        url.Values{"name": {"example"}},
+			wantMessage: "cannot specify postBody and x-www-form-urlencoded form at the same time",
+		},
+		{
+			name:        "unsupported body",
+			path:        "https://example.test/resource",
+			method:      http.MethodPost,
+			postBody:    make(chan int),
+			headers:     map[string]string{},
+			wantMessage: "invalid body type",
+		},
+		{
+			name:        "JSON encoding failure",
+			path:        "https://example.test/resource",
+			method:      http.MethodPost,
+			postBody:    make(chan int),
+			headers:     map[string]string{"Content-Type": "application/json"},
+			wantMessage: "unsupported type",
+		},
+		{
+			name:        "invalid URL",
+			path:        "https://example.test/%",
+			method:      http.MethodGet,
+			headers:     map[string]string{},
+			wantMessage: "invalid URL escape",
+		},
+		{
+			name:        "invalid method",
+			path:        "https://example.test/resource",
+			method:      "NOT VALID",
+			headers:     map[string]string{},
+			wantMessage: "invalid method",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := apiClient.PrepareRequest(
+				test.path,
+				test.method,
+				test.postBody,
+				test.headers,
+				nil,
+				test.form,
+			)
+			if err == nil {
+				t.Fatal("PrepareRequest() error = nil, want error")
+			}
+			if !strings.Contains(err.Error(), test.wantMessage) {
+				t.Fatalf("PrepareRequest() error = %q, want substring %q", err, test.wantMessage)
+			}
+		})
+	}
+}
+
+func TestSetBodySupportedTypes(t *testing.T) {
+	text := "pointer"
+	tests := []struct {
+		name        string
+		body        interface{}
+		contentType string
+		want        string
+	}{
+		{name: "reader", body: bytes.NewBufferString("reader"), contentType: "text/plain", want: "reader"},
+		{name: "bytes", body: []byte("bytes"), contentType: "application/octet-stream", want: "bytes"},
+		{name: "string", body: "string", contentType: "text/plain", want: "string"},
+		{name: "string pointer", body: &text, contentType: "text/plain", want: "pointer"},
+		{name: "JSON", body: map[string]string{"name": "value"}, contentType: "application/json", want: "{\"name\":\"value\"}\n"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := setBody(test.body, test.contentType)
+			if err != nil {
+				t.Fatalf("setBody() error = %v", err)
+			}
+			if got.String() != test.want {
+				t.Fatalf("setBody() = %q, want %q", got.String(), test.want)
+			}
+		})
+	}
+}
+
+func TestSetBodyRequestFile(t *testing.T) {
+	file, err := os.CreateTemp(t.TempDir(), "request-body-*")
+	if err != nil {
+		t.Fatalf("creating request file: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = file.Close()
+	})
+	if _, err := file.WriteString("file request body"); err != nil {
+		t.Fatalf("writing request file: %v", err)
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		t.Fatalf("rewinding request file: %v", err)
+	}
+
+	got, err := setBody(file, "application/octet-stream")
+	if err != nil {
+		t.Fatalf("setBody() error = %v", err)
+	}
+	if got.String() != "file request body" {
+		t.Fatalf("setBody() = %q, want file contents", got.String())
+	}
+}

--- a/client/configuration_test.go
+++ b/client/configuration_test.go
@@ -1,0 +1,61 @@
+package client
+
+import "testing"
+
+func TestNewConfiguration(t *testing.T) {
+	cfg := NewConfiguration()
+
+	if cfg.ServerURL != "https://api.thousandeyes.com/v7" {
+		t.Fatalf("ServerURL = %q, want %q", cfg.ServerURL, "https://api.thousandeyes.com/v7")
+	}
+	if cfg.Debug {
+		t.Fatal("Debug = true, want false")
+	}
+}
+
+func TestConfigurationFluentOptions(t *testing.T) {
+	cfg := NewConfiguration()
+
+	if got := cfg.WithAuthToken("test-token"); got != cfg {
+		t.Fatal("WithAuthToken returned a different configuration")
+	}
+	if cfg.AuthToken != "test-token" {
+		t.Fatalf("AuthToken = %q, want %q", cfg.AuthToken, "test-token")
+	}
+
+	if got := cfg.WithServerUrl("https://example.test/v7"); got != cfg {
+		t.Fatal("WithServerUrl returned a different configuration")
+	}
+	if cfg.ServerURL != "https://example.test/v7" {
+		t.Fatalf("ServerURL = %q, want %q", cfg.ServerURL, "https://example.test/v7")
+	}
+}
+
+func TestBuildUserAgent(t *testing.T) {
+	tests := []struct {
+		name      string
+		userAgent string
+		want      string
+	}{
+		{
+			name: "SDK only",
+			want: "ThousandEyesSDK-Go/" + SDKVersion(),
+		},
+		{
+			name:      "custom suffix",
+			userAgent: "example-client/1.0",
+			want:      "ThousandEyesSDK-Go/" + SDKVersion() + " example-client/1.0",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := NewConfiguration()
+			cfg.UserAgent = test.userAgent
+
+			if got := cfg.BuildUserAgent(); got != test.want {
+				t.Fatalf("BuildUserAgent() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}

--- a/client/decode_test.go
+++ b/client/decode_test.go
@@ -2,7 +2,9 @@ package client
 
 import (
 	"errors"
+	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -85,6 +87,47 @@ func TestDecodeStringBody(t *testing.T) {
 	}
 }
 
+func TestDecodeFileBody(t *testing.T) {
+	apiClient := newRequestTestClient(NewConfiguration())
+	body := []byte("file body")
+
+	t.Run("*os.File", func(t *testing.T) {
+		missingTempDir := filepath.Join(t.TempDir(), "missing")
+		t.Setenv("TMPDIR", missingTempDir)
+		t.Setenv("TMP", missingTempDir)
+		t.Setenv("TEMP", missingTempDir)
+
+		var destination os.File
+		err := apiClient.Decode(&destination, body, "application/octet-stream")
+		if !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("Decode() error = %v, want temporary-file creation error", err)
+		}
+	})
+
+	t.Run("**os.File", func(t *testing.T) {
+		var destination *os.File
+		if err := apiClient.Decode(&destination, body, "application/octet-stream"); err != nil {
+			t.Fatalf("Decode() error = %v", err)
+		}
+		if destination == nil {
+			t.Fatal("decoded file = nil")
+		}
+		t.Cleanup(func() {
+			name := destination.Name()
+			_ = destination.Close()
+			_ = os.Remove(name)
+		})
+
+		got, err := io.ReadAll(destination)
+		if err != nil {
+			t.Fatalf("ReadAll() error = %v", err)
+		}
+		if string(got) != string(body) {
+			t.Fatalf("decoded file body = %q, want %q", got, body)
+		}
+	})
+}
+
 func TestDecodeFailures(t *testing.T) {
 	apiClient := newRequestTestClient(NewConfiguration())
 
@@ -117,19 +160,6 @@ func TestDecodeFailures(t *testing.T) {
 		err := apiClient.Decode(&got, []byte(`{}`), "application/json")
 		if err == nil || !strings.Contains(err.Error(), "no unmarshalObj.UnmarshalJSON defined") {
 			t.Fatalf("Decode() error = %v, want missing custom unmarshaller error", err)
-		}
-	})
-
-	t.Run("former file response", func(t *testing.T) {
-		var got *os.File
-		err := apiClient.Decode(&got, []byte("file body"), "application/octet-stream")
-		if got != nil {
-			name := got.Name()
-			_ = got.Close()
-			_ = os.Remove(name)
-		}
-		if err == nil || err.Error() != "undefined response type" {
-			t.Fatalf("Decode() error = %v, want undefined response type", err)
 		}
 	})
 }

--- a/client/decode_test.go
+++ b/client/decode_test.go
@@ -1,0 +1,150 @@
+package client
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+)
+
+type decodedModel struct {
+	Name string `json:"name"`
+}
+
+type customDecodedModel struct {
+	Value string
+	Err   error
+}
+
+func (m *customDecodedModel) GetActualInstance() interface{} {
+	return m
+}
+
+func (m *customDecodedModel) UnmarshalJSON(data []byte) error {
+	if m.Err != nil {
+		return m.Err
+	}
+	m.Value = string(data)
+	return nil
+}
+
+type missingCustomUnmarshaller struct{}
+
+func (m *missingCustomUnmarshaller) GetActualInstance() interface{} {
+	return m
+}
+
+func TestDecodeJSONContentTypes(t *testing.T) {
+	contentTypes := []string{
+		"application/json",
+		"application/hal+json",
+		"application/problem+json",
+	}
+
+	for _, contentType := range contentTypes {
+		t.Run(contentType, func(t *testing.T) {
+			var got decodedModel
+			err := newRequestTestClient(NewConfiguration()).Decode(
+				&got,
+				[]byte(`{"name":"example"}`),
+				contentType,
+			)
+			if err != nil {
+				t.Fatalf("Decode() error = %v", err)
+			}
+			if got.Name != "example" {
+				t.Fatalf("decoded name = %q, want %q", got.Name, "example")
+			}
+		})
+	}
+}
+
+func TestDecodeEmptyBodyDoesNotMutateDestination(t *testing.T) {
+	got := decodedModel{Name: "unchanged"}
+	err := newRequestTestClient(NewConfiguration()).Decode(&got, nil, "application/json")
+	if err != nil {
+		t.Fatalf("Decode() error = %v", err)
+	}
+	if got.Name != "unchanged" {
+		t.Fatalf("decoded name = %q, want unchanged", got.Name)
+	}
+}
+
+func TestDecodeStringBody(t *testing.T) {
+	var got string
+	err := newRequestTestClient(NewConfiguration()).Decode(
+		&got,
+		[]byte("plain response"),
+		"application/octet-stream",
+	)
+	if err != nil {
+		t.Fatalf("Decode() error = %v", err)
+	}
+	if got != "plain response" {
+		t.Fatalf("decoded string = %q, want %q", got, "plain response")
+	}
+}
+
+func TestDecodeFailures(t *testing.T) {
+	apiClient := newRequestTestClient(NewConfiguration())
+
+	t.Run("malformed JSON", func(t *testing.T) {
+		var got decodedModel
+		if err := apiClient.Decode(&got, []byte(`{"name":`), "application/json"); err == nil {
+			t.Fatal("Decode() error = nil, want malformed JSON error")
+		}
+	})
+
+	t.Run("unsupported content type", func(t *testing.T) {
+		var got decodedModel
+		err := apiClient.Decode(&got, []byte("body"), "application/octet-stream")
+		if err == nil || err.Error() != "undefined response type" {
+			t.Fatalf("Decode() error = %v, want undefined response type", err)
+		}
+	})
+
+	t.Run("custom unmarshal failure", func(t *testing.T) {
+		wantErr := errors.New("custom failure")
+		got := customDecodedModel{Err: wantErr}
+		err := apiClient.Decode(&got, []byte(`{"name":"example"}`), "application/json")
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("Decode() error = %v, want %v", err, wantErr)
+		}
+	})
+
+	t.Run("missing custom unmarshaller", func(t *testing.T) {
+		var got missingCustomUnmarshaller
+		err := apiClient.Decode(&got, []byte(`{}`), "application/json")
+		if err == nil || !strings.Contains(err.Error(), "no unmarshalObj.UnmarshalJSON defined") {
+			t.Fatalf("Decode() error = %v, want missing custom unmarshaller error", err)
+		}
+	})
+
+	t.Run("former file response", func(t *testing.T) {
+		var got *os.File
+		err := apiClient.Decode(&got, []byte("file body"), "application/octet-stream")
+		if got != nil {
+			name := got.Name()
+			_ = got.Close()
+			_ = os.Remove(name)
+		}
+		if err == nil || err.Error() != "undefined response type" {
+			t.Fatalf("Decode() error = %v, want undefined response type", err)
+		}
+	})
+}
+
+func TestDecodeCustomUnmarshaller(t *testing.T) {
+	var got customDecodedModel
+	err := newRequestTestClient(NewConfiguration()).Decode(
+		&got,
+		[]byte(`{"name":"example"}`),
+		"application/json",
+	)
+	if err != nil {
+		t.Fatalf("Decode() error = %v", err)
+	}
+	if got.Value != `{"name":"example"}` {
+		t.Fatalf("custom decoded value = %q, want raw JSON", got.Value)
+	}
+}

--- a/client/decode_test.go
+++ b/client/decode_test.go
@@ -1,10 +1,10 @@
 package client
 
 import (
+	"bytes"
 	"errors"
 	"io"
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -87,47 +87,6 @@ func TestDecodeStringBody(t *testing.T) {
 	}
 }
 
-func TestDecodeFileBody(t *testing.T) {
-	apiClient := newRequestTestClient(NewConfiguration())
-	body := []byte("file body")
-
-	t.Run("*os.File", func(t *testing.T) {
-		missingTempDir := filepath.Join(t.TempDir(), "missing")
-		t.Setenv("TMPDIR", missingTempDir)
-		t.Setenv("TMP", missingTempDir)
-		t.Setenv("TEMP", missingTempDir)
-
-		var destination os.File
-		err := apiClient.Decode(&destination, body, "application/octet-stream")
-		if !errors.Is(err, os.ErrNotExist) {
-			t.Fatalf("Decode() error = %v, want temporary-file creation error", err)
-		}
-	})
-
-	t.Run("**os.File", func(t *testing.T) {
-		var destination *os.File
-		if err := apiClient.Decode(&destination, body, "application/octet-stream"); err != nil {
-			t.Fatalf("Decode() error = %v", err)
-		}
-		if destination == nil {
-			t.Fatal("decoded file = nil")
-		}
-		t.Cleanup(func() {
-			name := destination.Name()
-			_ = destination.Close()
-			_ = os.Remove(name)
-		})
-
-		got, err := io.ReadAll(destination)
-		if err != nil {
-			t.Fatalf("ReadAll() error = %v", err)
-		}
-		if string(got) != string(body) {
-			t.Fatalf("decoded file body = %q, want %q", got, body)
-		}
-	})
-}
-
 func TestDecodeFailures(t *testing.T) {
 	apiClient := newRequestTestClient(NewConfiguration())
 
@@ -176,5 +135,44 @@ func TestDecodeCustomUnmarshaller(t *testing.T) {
 	}
 	if got.Value != `{"name":"example"}` {
 		t.Fatalf("custom decoded value = %q, want raw JSON", got.Value)
+	}
+}
+
+func TestDecodeFileBody(t *testing.T) {
+	apiClient := newRequestTestClient(NewConfiguration())
+	want := []byte{0x00, 0x01, 0x7f, 0x80, 0xfe, 0xff}
+
+	var got *os.File
+	if err := apiClient.Decode(&got, want, "application/octet-stream"); err != nil {
+		t.Fatalf("Decode() error = %v", err)
+	}
+	if got == nil {
+		t.Fatal("Decode() returned a nil file")
+	}
+
+	fileName := got.Name()
+	t.Cleanup(func() {
+		if err := got.Close(); err != nil {
+			t.Errorf("close decoded file: %v", err)
+		}
+		if err := os.Remove(fileName); err != nil && !errors.Is(err, os.ErrNotExist) {
+			t.Errorf("remove decoded file: %v", err)
+		}
+	})
+
+	offset, err := got.Seek(0, io.SeekCurrent)
+	if err != nil {
+		t.Fatalf("get decoded file offset: %v", err)
+	}
+	if offset != 0 {
+		t.Fatalf("decoded file offset = %d, want 0", offset)
+	}
+
+	contents, err := io.ReadAll(got)
+	if err != nil {
+		t.Fatalf("read decoded file: %v", err)
+	}
+	if !bytes.Equal(contents, want) {
+		t.Fatalf("decoded file contents = %v, want %v", contents, want)
 	}
 }

--- a/enum_compatibility_test.go
+++ b/enum_compatibility_test.go
@@ -1,0 +1,60 @@
+package thousandeyes_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/thousandeyes/thousandeyes-sdk-go/v3/administrative"
+)
+
+func TestGeneratedEnumJSONCompatibility(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    administrative.CloudEnterpriseAgentType
+		wantErr bool
+	}{
+		{
+			name:  "known value",
+			input: `"cloud"`,
+			want:  administrative.CLOUDENTERPRISEAGENTTYPE_CLOUD,
+		},
+		{
+			name:  "explicit unknown value",
+			input: `"unknown"`,
+			want:  administrative.CLOUDENTERPRISEAGENTTYPE_UNKNOWN,
+		},
+		{
+			name:  "future value falls back",
+			input: `"future-agent-type"`,
+			want:  administrative.CLOUDENTERPRISEAGENTTYPE_UNKNOWN,
+		},
+		{
+			name:    "malformed JSON",
+			input:   `"unterminated`,
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var got administrative.CloudEnterpriseAgentType
+			err := json.Unmarshal([]byte(test.input), &got)
+			if test.wantErr {
+				if err == nil {
+					t.Fatal("json.Unmarshal() error = nil, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("json.Unmarshal() error = %v", err)
+			}
+			if got != test.want {
+				t.Fatalf("decoded enum = %q, want %q", got, test.want)
+			}
+			if !got.IsValid() {
+				t.Fatalf("decoded enum %q is not valid", got)
+			}
+		})
+	}
+}

--- a/internal/request/request_test.go
+++ b/internal/request/request_test.go
@@ -1,0 +1,104 @@
+package request
+
+import (
+	"errors"
+	"net/url"
+	"reflect"
+	"testing"
+	"time"
+)
+
+type mappedValue struct {
+	values map[string]interface{}
+	err    error
+}
+
+func (m mappedValue) ToMap() (map[string]interface{}, error) {
+	return m.values, m.err
+}
+
+func TestSelectHeaders(t *testing.T) {
+	if got := SelectHeaderContentType(nil); got != "" {
+		t.Fatalf("SelectHeaderContentType(nil) = %q, want empty", got)
+	}
+	if got := SelectHeaderContentType([]string{"text/plain", "application/json"}); got != "application/json" {
+		t.Fatalf("SelectHeaderContentType() = %q, want application/json", got)
+	}
+	if got := SelectHeaderContentType([]string{"text/plain", "application/xml"}); got != "text/plain" {
+		t.Fatalf("SelectHeaderContentType() = %q, want first value", got)
+	}
+	if got := SelectHeaderAccept([]string{"application/json", "text/plain"}); got != "application/json,text/plain" {
+		t.Fatalf("SelectHeaderAccept() = %q, want joined values", got)
+	}
+}
+
+func TestParameterValueToString(t *testing.T) {
+	if got := ParameterValueToString(42, "value"); got != "42" {
+		t.Fatalf("ParameterValueToString(scalar) = %q, want %q", got, "42")
+	}
+
+	mapped := &mappedValue{values: map[string]interface{}{"value": "mapped"}}
+	if got := ParameterValueToString(mapped, "value"); got != "mapped" {
+		t.Fatalf("ParameterValueToString(mapped) = %q, want %q", got, "mapped")
+	}
+
+	failing := &mappedValue{err: errors.New("mapping failed")}
+	if got := ParameterValueToString(failing, "value"); got != "" {
+		t.Fatalf("ParameterValueToString(failing) = %q, want empty", got)
+	}
+}
+
+func TestParameterAddToQuery(t *testing.T) {
+	values := url.Values{}
+	timestamp := time.Date(2026, time.July, 24, 12, 30, 45, 123, time.UTC)
+
+	ParameterAddToHeaderOrQuery(values, "string", "value", "")
+	ParameterAddToHeaderOrQuery(values, "integer", int64(-42), "")
+	ParameterAddToHeaderOrQuery(values, "unsigned", uint(42), "")
+	ParameterAddToHeaderOrQuery(values, "float", float64(1.5), "")
+	ParameterAddToHeaderOrQuery(values, "boolean", true, "")
+	ParameterAddToHeaderOrQuery(values, "repeated", []string{"one", "two"}, "")
+	ParameterAddToHeaderOrQuery(values, "csv", []string{"one", "two"}, "csv")
+	ParameterAddToHeaderOrQuery(values, "filter", map[string]interface{}{"name": "example"}, "")
+	ParameterAddToHeaderOrQuery(values, "timestamp", timestamp, "")
+	ParameterAddToHeaderOrQuery(values, "nil", nil, "")
+
+	want := url.Values{
+		"string":       {"value"},
+		"integer":      {"-42"},
+		"unsigned":     {"42"},
+		"float":        {"1.5"},
+		"boolean":      {"true"},
+		"repeated":     {"one", "two"},
+		"csv":          {"one,two"},
+		"filter[name]": {"example"},
+		"timestamp":    {timestamp.Format(time.RFC3339Nano)},
+		"nil":          {"null"},
+	}
+	if !reflect.DeepEqual(values, want) {
+		t.Fatalf("serialized query = %#v, want %#v", values, want)
+	}
+}
+
+func TestParameterAddToHeader(t *testing.T) {
+	headers := map[string]string{}
+	ParameterAddToHeaderOrQuery(headers, "X-Count", 3, "")
+
+	if got := headers["X-Count"]; got != "3" {
+		t.Fatalf("X-Count = %q, want %q", got, "3")
+	}
+}
+
+func TestParameterToJSON(t *testing.T) {
+	got, err := ParameterToJson(map[string]string{"name": "example"})
+	if err != nil {
+		t.Fatalf("ParameterToJson() error = %v", err)
+	}
+	if got != `{"name":"example"}` {
+		t.Fatalf("ParameterToJson() = %q, want JSON object", got)
+	}
+
+	if _, err := ParameterToJson(make(chan int)); err == nil {
+		t.Fatal("ParameterToJson(channel) error = nil, want error")
+	}
+}

--- a/internal/utils/strict_decoder_test.go
+++ b/internal/utils/strict_decoder_test.go
@@ -1,0 +1,33 @@
+package utils
+
+import "testing"
+
+type strictModel struct {
+	Name string `json:"name"`
+}
+
+func TestNewStrictDecoder(t *testing.T) {
+	t.Run("known fields", func(t *testing.T) {
+		var got strictModel
+		if err := NewStrictDecoder([]byte(`{"name":"example"}`)).Decode(&got); err != nil {
+			t.Fatalf("Decode() error = %v", err)
+		}
+		if got.Name != "example" {
+			t.Fatalf("Name = %q, want %q", got.Name, "example")
+		}
+	})
+
+	t.Run("unknown field", func(t *testing.T) {
+		var got strictModel
+		if err := NewStrictDecoder([]byte(`{"name":"example","unknown":true}`)).Decode(&got); err == nil {
+			t.Fatal("Decode() error = nil, want unknown-field error")
+		}
+	})
+
+	t.Run("malformed JSON", func(t *testing.T) {
+		var got strictModel
+		if err := NewStrictDecoder([]byte(`{"name":`)).Decode(&got); err == nil {
+			t.Fatal("Decode() error = nil, want malformed JSON error")
+		}
+	})
+}


### PR DESCRIPTION
## What changed

- Added behavioral unit tests for client configuration, request preparation, response decoding, retry/backoff handling, API error formatting, strict decoding, request helpers, and unknown-enum fallback behavior.
- Hardened retry handling so malformed or overflowing `Retry-After` values fall through safely without being reparsed by the default backoff implementation.
- Updated RFC7807 error formatting to safely handle generated pointer-backed and partially populated models.
- Removed response decoding into `os.File`; request file uploads remain supported. The SDK is in alpha, so this intentionally removes the unused response behavior rather than preserving it.

## Why

The shared Go SDK v3 runtime previously had no checked-in behavioral tests, so CI only provided compilation-level confidence. This adds focused coverage for reusable runtime paths and protects unknown-enum compatibility behavior in generated SDK source.

No generator changes are required: the existing generator already emits the unknown-enum fallback behavior, and this PR verifies it in generated SDK source.

## Impact

The tests are hermetic and require no ThousandEyes credentials or external network access. Runtime behavior is unchanged for valid responses, while malformed retry headers and partial RFC7807 errors are handled safely. File response decoding is removed as an accepted alpha-stage breaking change.

## Validation

- `go test ./...`
- `go test -race -coverprofile=coverage.txt -covermode=atomic ./...`
- `go vet ./...`
- `git diff --check`

Race-enabled coverage includes 81.9% for `client`, 92.0% for `internal/error`, and 79.5% for `internal/request`.
