### PR TITLE
Centralize Go SDK error decoding

### DIFF
--- a/internal/error/generic_error.go
+++ b/internal/error/generic_error.go
@@ -2,7 +2,7 @@ package error
 
 import (
 	"fmt"
-	"reflect"
+	"net/http"
 	"strings"
 )
 
@@ -17,24 +17,81 @@ func (g GenericAPIError) Error() string {
 	return g.ErrorMessage
 }
 
-// FormatErrorMessage format error message using title and detail when model implements rfc7807
-func FormatErrorMessage(status string, responseBody string, v interface{}) string {
-	str := responseBody
-	metaValue := reflect.ValueOf(v).Elem()
-
-	if metaValue.Kind() == reflect.Struct {
-		field := metaValue.FieldByName("Title")
-		if field != (reflect.Value{}) {
-			str = fmt.Sprintf("%s", field.Interface())
-		}
-
-		field = metaValue.FieldByName("Detail")
-		if field != (reflect.Value{}) {
-			str = fmt.Sprintf("%s (%s)", str, field.Interface())
-		}
+// DecodeError decodes a modeled API error and preserves the response details.
+func DecodeError(
+	decode func(interface{}, []byte, string) error,
+	model interface{},
+	body []byte,
+	response *http.Response,
+) *GenericAPIError {
+	apiErr := &GenericAPIError{
+		Body:         body,
+		ErrorMessage: response.Status,
+	}
+	if model == nil {
+		return apiErr
 	}
 
-	return strings.TrimSpace(fmt.Sprintf("%s %s", status, str))
+	if err := decode(model, body, response.Header.Get("Content-Type")); err != nil {
+		apiErr.ErrorMessage = err.Error()
+		return apiErr
+	}
+
+	apiErr.ErrorMessage = FormatErrorMessage(response.Status, string(body), model)
+	apiErr.Model = model
+	return apiErr
+}
+
+type titleProvider interface {
+	GetTitleOk() (*string, bool)
+}
+
+type detailProvider interface {
+	GetDetailOk() (*string, bool)
+}
+
+// FormatErrorMessage format error message using title and detail when model implements rfc7807
+func FormatErrorMessage(status string, responseBody string, v interface{}) string {
+	message := strings.TrimSpace(responseBody)
+	title, hasTitle := problemTitle(v)
+	detail, hasDetail := problemDetail(v)
+
+	switch {
+	case hasTitle && hasDetail:
+		message = fmt.Sprintf("%s (%s)", title, detail)
+	case hasTitle:
+		message = title
+	case hasDetail:
+		message = detail
+	}
+
+	return strings.TrimSpace(fmt.Sprintf("%s %s", status, message))
+}
+
+func problemTitle(v interface{}) (string, bool) {
+	provider, ok := v.(titleProvider)
+	if !ok {
+		return "", false
+	}
+
+	title, ok := provider.GetTitleOk()
+	if !ok || title == nil || *title == "" {
+		return "", false
+	}
+	return *title, true
+}
+
+func problemDetail(v interface{}) (string, bool) {
+	provider, ok := v.(detailProvider)
+	if !ok {
+		return "", false
+	}
+
+	detail, ok := provider.GetDetailOk()
+	if !ok || detail == nil || *detail == "" {
+		return "", false
+	}
+	return *detail, true
 }
 
 // ReportError Prevent trying to import "fmt"

--- a/internal/error/generic_error_characterization_test.go
+++ b/internal/error/generic_error_characterization_test.go
@@ -1,0 +1,230 @@
+package error_test
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/thousandeyes/thousandeyes-sdk-go/v3/bgpmonitors"
+	"github.com/thousandeyes/thousandeyes-sdk-go/v3/client"
+	internalerror "github.com/thousandeyes/thousandeyes-sdk-go/v3/internal/error"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}
+
+func TestGenericAPIErrorErrorReturnsConfiguredMessage(t *testing.T) {
+	apiErr := internalerror.GenericAPIError{
+		ErrorMessage: "403 Forbidden access denied",
+	}
+
+	if got, want := apiErr.Error(), apiErr.ErrorMessage; got != want {
+		t.Fatalf("GenericAPIError.Error() = %q, want %q", got, want)
+	}
+}
+
+func TestGeneratedAPIErrorDecoding(t *testing.T) {
+	tests := []struct {
+		name             string
+		statusCode       int
+		contentType      string
+		body             string
+		wantErrorMessage string
+		assertError      func(*testing.T, *internalerror.GenericAPIError)
+	}{
+		{
+			name:        "modeled RFC7807 response preserves body and decodes model",
+			statusCode:  http.StatusForbidden,
+			contentType: "application/problem+json",
+			body:        `{"type":"https://example.com/problems/forbidden","title":"Access denied","status":403,"detail":"The token lacks permission","instance":"/monitors"}`,
+			assertError: func(t *testing.T, apiErr *internalerror.GenericAPIError) {
+				t.Helper()
+
+				model, ok := apiErr.Model.(*bgpmonitors.Error)
+				if !ok {
+					t.Fatalf("GenericAPIError.Model has type %T, want *bgpmonitors.Error", apiErr.Model)
+				}
+
+				want := bgpmonitors.Error{}
+				want.SetType("https://example.com/problems/forbidden")
+				want.SetTitle("Access denied")
+				want.SetStatus(http.StatusForbidden)
+				want.SetDetail("The token lacks permission")
+				want.SetInstance("/monitors")
+				if !reflect.DeepEqual(*model, want) {
+					t.Errorf("GenericAPIError.Model = %#v, want %#v", *model, want)
+				}
+			},
+		},
+		{
+			name:             "modeled RFC7807 response without title or detail uses trimmed raw body",
+			statusCode:       http.StatusForbidden,
+			contentType:      "application/problem+json",
+			body:             "\n  {\"type\":\"https://example.com/problems/forbidden\",\"status\":403} \t",
+			wantErrorMessage: `403 Forbidden {"type":"https://example.com/problems/forbidden","status":403}`,
+			assertError: func(t *testing.T, apiErr *internalerror.GenericAPIError) {
+				t.Helper()
+
+				model, ok := apiErr.Model.(*bgpmonitors.Error)
+				if !ok {
+					t.Fatalf("GenericAPIError.Model has type %T, want *bgpmonitors.Error", apiErr.Model)
+				}
+
+				want := bgpmonitors.Error{}
+				want.SetType("https://example.com/problems/forbidden")
+				want.SetStatus(http.StatusForbidden)
+				if !reflect.DeepEqual(*model, want) {
+					t.Errorf("GenericAPIError.Model = %#v, want %#v", *model, want)
+				}
+			},
+		},
+		{
+			name:             "modeled non-RFC JSON preserves compatibility message and model",
+			statusCode:       http.StatusUnauthorized,
+			contentType:      "application/json",
+			body:             `{"error":"unauthorized","error_description":"token expired"}`,
+			wantErrorMessage: `401 Unauthorized {"error":"unauthorized","error_description":"token expired"}`,
+			assertError: func(t *testing.T, apiErr *internalerror.GenericAPIError) {
+				t.Helper()
+
+				model, ok := apiErr.Model.(*bgpmonitors.UnauthorizedError)
+				if !ok {
+					t.Fatalf("GenericAPIError.Model has type %T, want *bgpmonitors.UnauthorizedError", apiErr.Model)
+				}
+
+				want := bgpmonitors.UnauthorizedError{}
+				want.SetError("unauthorized")
+				want.SetErrorDescription("token expired")
+				if !reflect.DeepEqual(*model, want) {
+					t.Errorf("GenericAPIError.Model = %#v, want %#v", *model, want)
+				}
+			},
+		},
+		{
+			name:             "malformed modeled JSON preserves decoder error and omits model",
+			statusCode:       http.StatusForbidden,
+			contentType:      "application/problem+json",
+			body:             `{"title":`,
+			wantErrorMessage: "unexpected end of JSON input",
+			assertError: func(t *testing.T, apiErr *internalerror.GenericAPIError) {
+				t.Helper()
+				if apiErr.Model != nil {
+					t.Errorf("GenericAPIError.Model = %#v, want nil", apiErr.Model)
+				}
+			},
+		},
+		{
+			name:             "non-JSON modeled response preserves decoder error and omits model",
+			statusCode:       http.StatusForbidden,
+			contentType:      "text/plain",
+			body:             "gateway exploded",
+			wantErrorMessage: "undefined response type",
+			assertError: func(t *testing.T, apiErr *internalerror.GenericAPIError) {
+				t.Helper()
+				if apiErr.Model != nil {
+					t.Errorf("GenericAPIError.Model = %#v, want nil", apiErr.Model)
+				}
+			},
+		},
+		{
+			name:             "empty modeled response uses status and zero-value model",
+			statusCode:       http.StatusForbidden,
+			contentType:      "application/problem+json",
+			body:             "",
+			wantErrorMessage: "403 Forbidden",
+			assertError: func(t *testing.T, apiErr *internalerror.GenericAPIError) {
+				t.Helper()
+
+				model, ok := apiErr.Model.(*bgpmonitors.Error)
+				if !ok {
+					t.Fatalf("GenericAPIError.Model has type %T, want *bgpmonitors.Error", apiErr.Model)
+				}
+				if !reflect.DeepEqual(*model, bgpmonitors.Error{}) {
+					t.Errorf("GenericAPIError.Model = %#v, want zero-value bgpmonitors.Error", *model)
+				}
+			},
+		},
+		{
+			name:             "unmodeled response uses status and omits model",
+			statusCode:       http.StatusTeapot,
+			contentType:      "application/json",
+			body:             `{"message":"short and stout"}`,
+			wantErrorMessage: "418 I'm a teapot",
+			assertError: func(t *testing.T, apiErr *internalerror.GenericAPIError) {
+				t.Helper()
+				if apiErr.Model != nil {
+					t.Errorf("GenericAPIError.Model = %#v, want nil", apiErr.Model)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			apiErr := executeBGPMonitorsErrorResponse(
+				t,
+				tt.statusCode,
+				tt.contentType,
+				tt.body,
+			)
+
+			if got, want := string(apiErr.Body), tt.body; got != want {
+				t.Errorf("GenericAPIError.Body = %q, want %q", got, want)
+			}
+			if tt.wantErrorMessage != "" && apiErr.ErrorMessage != tt.wantErrorMessage {
+				t.Errorf("GenericAPIError.ErrorMessage = %q, want %q", apiErr.ErrorMessage, tt.wantErrorMessage)
+			}
+			tt.assertError(t, apiErr)
+		})
+	}
+}
+
+func executeBGPMonitorsErrorResponse(
+	t *testing.T,
+	statusCode int,
+	contentType string,
+	body string,
+) *internalerror.GenericAPIError {
+	t.Helper()
+
+	transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		if got, want := request.Method, http.MethodGet; got != want {
+			t.Errorf("request method = %q, want %q", got, want)
+		}
+		if got, want := request.URL.Path, "/monitors"; got != want {
+			t.Errorf("request path = %q, want %q", got, want)
+		}
+
+		return &http.Response{
+			StatusCode: statusCode,
+			Status:     fmt.Sprintf("%d %s", statusCode, http.StatusText(statusCode)),
+			Header: http.Header{
+				"Content-Type": []string{contentType},
+			},
+			Body:    io.NopCloser(strings.NewReader(body)),
+			Request: request,
+		}, nil
+	})
+
+	cfg := client.NewConfiguration().WithServerUrl("https://example.invalid")
+	cfg.HTTPClient = &http.Client{Transport: transport}
+	apiClient := client.NewAPIClient(cfg)
+	api := (*bgpmonitors.BGPMonitorsAPIService)(&apiClient.Common)
+
+	_, _, err := api.GetBgpMonitors().Execute()
+	if err == nil {
+		t.Fatal("GetBgpMonitors().Execute() returned nil error, want *GenericAPIError")
+	}
+
+	apiErr, ok := err.(*internalerror.GenericAPIError)
+	if !ok {
+		t.Fatalf("GetBgpMonitors().Execute() error has type %T, want *GenericAPIError", err)
+	}
+	return apiErr
+}

--- a/internal/error/generic_error_test.go
+++ b/internal/error/generic_error_test.go
@@ -1,0 +1,216 @@
+package error_test
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/thousandeyes/thousandeyes-sdk-go/v3/client"
+	internalerror "github.com/thousandeyes/thousandeyes-sdk-go/v3/internal/error"
+)
+
+type problemDetails struct {
+	Title  *string `json:"title,omitempty"`
+	Detail *string `json:"detail,omitempty"`
+}
+
+type messageDetails struct {
+	Message string `json:"message"`
+}
+
+func (p *problemDetails) GetTitleOk() (*string, bool) {
+	if p == nil || p.Title == nil {
+		return nil, false
+	}
+	return p.Title, true
+}
+
+func (p *problemDetails) GetDetailOk() (*string, bool) {
+	if p == nil || p.Detail == nil {
+		return nil, false
+	}
+	return p.Detail, true
+}
+
+func TestDecodeErrorFormatsModeledMessages(t *testing.T) {
+	apiClient := &client.APIClient{}
+	tests := []struct {
+		name         string
+		body         string
+		model        interface{}
+		wantMessage  string
+		wantModel    interface{}
+		contentType  string
+		responseCode int
+	}{
+		{
+			name:         "RFC7807 title and detail",
+			body:         `{"title":"Access denied","detail":"The token lacks permission"}`,
+			model:        &problemDetails{},
+			wantMessage:  "403 Forbidden Access denied (The token lacks permission)",
+			wantModel:    problemDetails{Title: stringPointer("Access denied"), Detail: stringPointer("The token lacks permission")},
+			contentType:  "application/problem+json",
+			responseCode: http.StatusForbidden,
+		},
+		{
+			name:         "RFC7807 title only",
+			body:         `{"title":"Access denied"}`,
+			model:        &problemDetails{},
+			wantMessage:  "403 Forbidden Access denied",
+			wantModel:    problemDetails{Title: stringPointer("Access denied")},
+			contentType:  "application/problem+json",
+			responseCode: http.StatusForbidden,
+		},
+		{
+			name:         "RFC7807 detail only",
+			body:         `{"detail":"The token lacks permission"}`,
+			model:        &problemDetails{},
+			wantMessage:  "403 Forbidden The token lacks permission",
+			wantModel:    problemDetails{Detail: stringPointer("The token lacks permission")},
+			contentType:  "application/problem+json",
+			responseCode: http.StatusForbidden,
+		},
+		{
+			name:         "RFC7807 neither title nor detail uses trimmed raw body",
+			body:         "\n  {\"type\":\"https://example.com/problems/forbidden\",\"status\":403} \t",
+			model:        &problemDetails{},
+			wantMessage:  `403 Forbidden {"type":"https://example.com/problems/forbidden","status":403}`,
+			wantModel:    problemDetails{},
+			contentType:  "application/problem+json",
+			responseCode: http.StatusForbidden,
+		},
+		{
+			name:         "non-RFC model falls back to raw body",
+			body:         `{"message":"Access denied"}`,
+			model:        &messageDetails{},
+			wantMessage:  `403 Forbidden {"message":"Access denied"}`,
+			wantModel:    messageDetails{Message: "Access denied"},
+			contentType:  "application/json",
+			responseCode: http.StatusForbidden,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := []byte(tt.body)
+			response := errorResponse(tt.responseCode, tt.contentType)
+
+			apiErr := internalerror.DecodeError(apiClient.Decode, tt.model, body, response)
+
+			if got := apiErr.ErrorMessage; got != tt.wantMessage {
+				t.Errorf("GenericAPIError.ErrorMessage = %q, want %q", got, tt.wantMessage)
+			}
+			if !bytes.Equal(apiErr.Body, body) {
+				t.Errorf("GenericAPIError.Body = %q, want %q", apiErr.Body, body)
+			}
+			if apiErr.Model != tt.model {
+				t.Errorf("GenericAPIError.Model = %p, want original model %p", apiErr.Model, tt.model)
+			}
+			if got := reflect.ValueOf(apiErr.Model).Elem().Interface(); !reflect.DeepEqual(got, tt.wantModel) {
+				t.Errorf("GenericAPIError.Model value = %#v, want %#v", got, tt.wantModel)
+			}
+		})
+	}
+}
+
+func TestDecodeErrorPreservesDecodeFailuresAndEmptyBodies(t *testing.T) {
+	apiClient := &client.APIClient{}
+	tests := []struct {
+		name        string
+		body        string
+		contentType string
+		wantMessage string
+		wantModel   bool
+	}{
+		{
+			name:        "malformed JSON",
+			body:        `{"title":`,
+			contentType: "application/problem+json",
+			wantMessage: "unexpected end of JSON input",
+		},
+		{
+			name:        "non-JSON response",
+			body:        "gateway exploded",
+			contentType: "text/plain",
+			wantMessage: "undefined response type",
+		},
+		{
+			name:        "empty modeled response",
+			contentType: "application/problem+json",
+			wantMessage: "403 Forbidden",
+			wantModel:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := []byte(tt.body)
+			model := &problemDetails{}
+
+			apiErr := internalerror.DecodeError(
+				apiClient.Decode,
+				model,
+				body,
+				errorResponse(http.StatusForbidden, tt.contentType),
+			)
+
+			if got := apiErr.ErrorMessage; got != tt.wantMessage {
+				t.Errorf("GenericAPIError.ErrorMessage = %q, want %q", got, tt.wantMessage)
+			}
+			if !bytes.Equal(apiErr.Body, body) {
+				t.Errorf("GenericAPIError.Body = %q, want %q", apiErr.Body, body)
+			}
+			if tt.wantModel && apiErr.Model != model {
+				t.Errorf("GenericAPIError.Model = %p, want original model %p", apiErr.Model, model)
+			}
+			if !tt.wantModel && apiErr.Model != nil {
+				t.Errorf("GenericAPIError.Model = %#v, want nil", apiErr.Model)
+			}
+		})
+	}
+}
+
+func TestDecodeErrorSkipsDecodeForUnmodeledResponse(t *testing.T) {
+	body := []byte(`{"message":"short and stout"}`)
+	decodeCalled := false
+	decode := func(interface{}, []byte, string) error {
+		decodeCalled = true
+		return nil
+	}
+
+	apiErr := internalerror.DecodeError(
+		decode,
+		nil,
+		body,
+		errorResponse(http.StatusTeapot, "application/json"),
+	)
+
+	if decodeCalled {
+		t.Error("decode was called for an unmodeled response")
+	}
+	if got, want := apiErr.ErrorMessage, "418 I'm a teapot"; got != want {
+		t.Errorf("GenericAPIError.ErrorMessage = %q, want %q", got, want)
+	}
+	if !bytes.Equal(apiErr.Body, body) {
+		t.Errorf("GenericAPIError.Body = %q, want %q", apiErr.Body, body)
+	}
+	if apiErr.Model != nil {
+		t.Errorf("GenericAPIError.Model = %#v, want nil", apiErr.Model)
+	}
+}
+
+func errorResponse(statusCode int, contentType string) *http.Response {
+	return &http.Response{
+		StatusCode: statusCode,
+		Status:     fmt.Sprintf("%d %s", statusCode, http.StatusText(statusCode)),
+		Header: http.Header{
+			"Content-Type": []string{contentType},
+		},
+	}
+}
+
+func stringPointer(value string) *string {
+	return &value
+}


### PR DESCRIPTION
## Summary

- Add a shared internal decoder for modeled and unmodeled API errors.
- Preserve raw response bodies, decoded models, status messages, and useful decoder failures.
- Correct RFC7807 title/detail formatting, including title-only, detail-only, and raw-body fallback cases.
- Add black-box characterization and focused helper tests for existing error behavior.

## Motivation and context

Error decoding behavior needs a single internal implementation that generated services can delegate to. This change establishes that runtime helper while retaining the existing `GenericAPIError` contract and compatibility-first messages.

## Changes

- Add `internal/error.DecodeError` with modeled and unmodeled response handling.
- Populate `GenericAPIError.Model` only after successful decoding.
- Preserve exact response bodies and decoder error messages.
- Replace reflection-based RFC7807 formatting with title/detail provider interfaces.
- Trim raw-body fallback messages without modifying the retained body.
- Characterize the current generated API path using a real API client and fake HTTP transport.

## Compatibility

- `GenericAPIError` fields and `Error()` are unchanged.
- The helper remains inaccessible to external consumers through Go's `internal` boundary.
- Generated API files and public API signatures are unchanged in this pull request.
- Generated service regeneration is intentionally excluded from this change.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Build/CI change
- [x] Code quality improvement

## Testing

- `go test ./...`
- `go vet ./...`

## Generate output

```go
if localVarHTTPResponse.StatusCode >= 300 {
		if localVarHTTPResponse.StatusCode == 401 {
			var v UnauthorizedError
			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
		}
		if localVarHTTPResponse.StatusCode == 403 {
			var v Error
			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
		}
		if localVarHTTPResponse.StatusCode == 404 {
			var v Error
			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
		}
		if localVarHTTPResponse.StatusCode == 429 {
			var v Error
			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
		}
		if localVarHTTPResponse.StatusCode == 500 {
			var v ApiError
			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
		}
		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
	}
```