### PR TITLE
Go SDK page-based pagination

### DIFF
--- a/administrative/api_user_events.go
+++ b/administrative/api_user_events.go
@@ -11,9 +11,11 @@ package administrative
 
 import (
 	"bytes"
+	"context"
 	"github.com/thousandeyes/thousandeyes-sdk-go/v3/client"
 	internalerror "github.com/thousandeyes/thousandeyes-sdk-go/v3/internal/error"
 	"github.com/thousandeyes/thousandeyes-sdk-go/v3/internal/request"
+	"github.com/thousandeyes/thousandeyes-sdk-go/v3/pagination"
 	"io"
 	"net/http"
 	"net/url"
@@ -33,6 +35,7 @@ type ApiGetUserEventsRequest struct {
 	startDate *time.Time
 	endDate *time.Time
 	cursor *string
+	ctx context.Context
 }
 
 // A unique identifier associated with your account group. You can retrieve your &#x60;AccountGroupId&#x60; from the &#x60;/account-groups&#x60; endpoint. Note that you must be assigned to the target account group. Specifying this parameter without being assigned to the target account group will result in an error response.
@@ -73,6 +76,42 @@ func (r ApiGetUserEventsRequest) Cursor(cursor string) ApiGetUserEventsRequest {
 
 func (r ApiGetUserEventsRequest) Execute() (*AuditUserEvents, *http.Response, error) {
 	return r.ApiService.GetUserEventsExecute(r)
+}
+
+func (r ApiGetUserEventsRequest) ExecuteContext(ctx context.Context) (*AuditUserEvents, *http.Response, error) {
+	r.ctx = ctx
+	return r.Execute()
+}
+
+func (r ApiGetUserEventsRequest) Paginated() *pagination.Pager[AuditUserEvents] {
+	return pagination.NewPager(
+		r.cursor,
+		func(ctx context.Context, cursor *string) (*AuditUserEvents, *http.Response, error) {
+			pageRequest := r
+			if cursor != nil {
+				pageRequest = pageRequest.Cursor(*cursor)
+			}
+			return pageRequest.ExecuteContext(ctx)
+		},
+		func(page *AuditUserEvents) (string, bool) {
+			if page == nil {
+				return "", false
+			}
+			links, ok := page.GetLinksOk()
+			if !ok {
+				return "", false
+			}
+			next, ok := links.GetNextOk()
+			if !ok {
+				return "", false
+			}
+			href, ok := next.GetHrefOk()
+			if !ok {
+				return "", true
+			}
+			return *href, true
+		},
+	)
 }
 
 /*
@@ -153,6 +192,9 @@ func (a *UserEventsAPIService) GetUserEventsExecute(r ApiGetUserEventsRequest) (
 		return localVarReturnValue, nil, err
 	}
 
+	if r.ctx != nil {
+		req = req.WithContext(r.ctx)
+	}
 	localVarHTTPResponse, err := a.Client.CallAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarReturnValue, localVarHTTPResponse, err

--- a/endpointtestresults/api_local_network_endpoint_test_results.go
+++ b/endpointtestresults/api_local_network_endpoint_test_results.go
@@ -11,9 +11,11 @@ package endpointtestresults
 
 import (
 	"bytes"
+	"context"
 	"github.com/thousandeyes/thousandeyes-sdk-go/v3/client"
 	internalerror "github.com/thousandeyes/thousandeyes-sdk-go/v3/internal/error"
 	"github.com/thousandeyes/thousandeyes-sdk-go/v3/internal/request"
+	"github.com/thousandeyes/thousandeyes-sdk-go/v3/pagination"
 	"io"
 	"net/http"
 	"net/url"
@@ -35,6 +37,7 @@ type ApiFilterLocalNetworksTestResultsTopologiesRequest struct {
 	cursor *string
 	expand *[]ExpandLocalNetworkTopologyOptions
 	endpointNetworkTopologyResultRequest *EndpointNetworkTopologyResultRequest
+	ctx context.Context
 }
 
 // A unique identifier associated with your account group. You can retrieve your &#x60;AccountGroupId&#x60; from the &#x60;/account-groups&#x60; endpoint. Note that you must be assigned to the target account group. Specifying this parameter without being assigned to the target account group will result in an error response.
@@ -80,6 +83,42 @@ func (r ApiFilterLocalNetworksTestResultsTopologiesRequest) EndpointNetworkTopol
 
 func (r ApiFilterLocalNetworksTestResultsTopologiesRequest) Execute() (*LocalNetworkTopologyResults, *http.Response, error) {
 	return r.ApiService.FilterLocalNetworksTestResultsTopologiesExecute(r)
+}
+
+func (r ApiFilterLocalNetworksTestResultsTopologiesRequest) ExecuteContext(ctx context.Context) (*LocalNetworkTopologyResults, *http.Response, error) {
+	r.ctx = ctx
+	return r.Execute()
+}
+
+func (r ApiFilterLocalNetworksTestResultsTopologiesRequest) Paginated() *pagination.Pager[LocalNetworkTopologyResults] {
+	return pagination.NewPager(
+		r.cursor,
+		func(ctx context.Context, cursor *string) (*LocalNetworkTopologyResults, *http.Response, error) {
+			pageRequest := r
+			if cursor != nil {
+				pageRequest = pageRequest.Cursor(*cursor)
+			}
+			return pageRequest.ExecuteContext(ctx)
+		},
+		func(page *LocalNetworkTopologyResults) (string, bool) {
+			if page == nil {
+				return "", false
+			}
+			links, ok := page.GetLinksOk()
+			if !ok {
+				return "", false
+			}
+			next, ok := links.GetNextOk()
+			if !ok {
+				return "", false
+			}
+			href, ok := next.GetHrefOk()
+			if !ok {
+				return "", true
+			}
+			return *href, true
+		},
+	)
 }
 
 /*
@@ -206,6 +245,9 @@ func (a *LocalNetworkEndpointTestResultsAPIService) FilterLocalNetworksTestResul
 		return localVarReturnValue, nil, err
 	}
 
+	if r.ctx != nil {
+		req = req.WithContext(r.ctx)
+	}
 	localVarHTTPResponse, err := a.Client.CallAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarReturnValue, localVarHTTPResponse, err

--- a/pagination/generated_integration_test.go
+++ b/pagination/generated_integration_test.go
@@ -1,0 +1,236 @@
+package pagination_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/thousandeyes/thousandeyes-sdk-go/v3/administrative"
+	"github.com/thousandeyes/thousandeyes-sdk-go/v3/client"
+	"github.com/thousandeyes/thousandeyes-sdk-go/v3/endpointtestresults"
+)
+
+type recordedRequest struct {
+	method      string
+	path        string
+	query       url.Values
+	contentType string
+	body        []byte
+}
+
+type pageRecorder struct {
+	t      *testing.T
+	method string
+	path   string
+	pages  []string
+	calls  []recordedRequest
+}
+
+func (r *pageRecorder) ServeHTTP(w http.ResponseWriter, request *http.Request) {
+	body, err := io.ReadAll(request.Body)
+	if err != nil {
+		r.t.Errorf("read request body: %v", err)
+	}
+	r.calls = append(r.calls, recordedRequest{
+		method:      request.Method,
+		path:        request.URL.Path,
+		query:       request.URL.Query(),
+		contentType: request.Header.Get("Content-Type"),
+		body:        body,
+	})
+	index := len(r.calls) - 1
+	if index >= len(r.pages) {
+		r.t.Errorf("unexpected request %d", index+1)
+		http.Error(w, "unexpected request", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-Page", strconv.Itoa(index+1))
+	_, _ = io.WriteString(w, r.pages[index])
+}
+
+type contextKey struct{}
+
+type contextObserver struct {
+	base http.RoundTripper
+	saw  bool
+}
+
+func (o *contextObserver) RoundTrip(request *http.Request) (*http.Response, error) {
+	if request.Context().Value(contextKey{}) == "wired" {
+		o.saw = true
+	}
+	return o.base.RoundTrip(request)
+}
+
+func TestGeneratedGetUserEventsPagination(t *testing.T) {
+	recorder := &pageRecorder{
+		t:      t,
+		method: http.MethodGet,
+		path:   "/audit-user-events",
+		pages: []string{
+			`{"startDate":"2026-01-01T00:00:00Z","_links":{"next":{"href":"https://other.example/wrong?cursor=get-next"}}}`,
+			`{"startDate":"2026-01-02T00:00:00Z","_links":{}}`,
+			`{"startDate":"2026-01-03T00:00:00Z","_links":{}}`,
+		},
+	}
+	server := httptest.NewServer(recorder)
+	defer server.Close()
+
+	observer := &contextObserver{base: server.Client().Transport}
+	apiClient := newTestClient(server.URL, observer)
+	api := (*administrative.UserEventsAPIService)(&apiClient.Common)
+	request := api.GetUserEvents().
+		Aid("account").
+		UseAllPermittedAids(true).
+		Window("1h")
+	pager := request.Paginated()
+	if len(recorder.calls) != 0 {
+		t.Fatal("Paginated performed a request")
+	}
+
+	ctx := context.WithValue(context.Background(), contextKey{}, "wired")
+	first, firstHTTP, err := pager.NextPage(ctx)
+	if err != nil || first == nil || first.StartDate == nil || firstHTTP == nil ||
+		firstHTTP.Header.Get("X-Page") != "1" {
+		t.Fatalf("first page = (%#v, %#v, %v)", first, firstHTTP, err)
+	}
+	if !observer.saw {
+		t.Fatal("NextPage context was not wired to the HTTP request")
+	}
+	second, secondHTTP, err := pager.NextPage(context.Background())
+	if err != nil || second == nil || second.StartDate == nil || secondHTTP == nil ||
+		secondHTTP.Header.Get("X-Page") != "2" {
+		t.Fatalf("second page = (%#v, %#v, %v)", second, secondHTTP, err)
+	}
+	page, response, err := pager.NextPage(context.Background())
+	assertCompleted(t, page, response, err)
+	assertReplay(t, recorder.calls, http.MethodGet, "/audit-user-events", "get-next")
+	if got := recorder.calls[0].query.Encode(); got != "aid=account&useAllPermittedAids=true&window=1h" {
+		t.Fatalf("GET query = %q", got)
+	}
+	legacy, legacyHTTP, err := request.Execute()
+	if err != nil || legacy == nil || legacy.StartDate == nil || legacyHTTP == nil ||
+		legacyHTTP.Header.Get("X-Page") != "3" {
+		t.Fatalf("legacy Execute = (%#v, %#v, %v)", legacy, legacyHTTP, err)
+	}
+	assertLegacyRequest(t, recorder.calls, http.MethodGet, recorder.path)
+}
+
+func TestGeneratedFilterLocalNetworksPagination(t *testing.T) {
+	recorder := &pageRecorder{
+		t:      t,
+		method: http.MethodPost,
+		path:   "/endpoint/test-results/local-networks/topologies/filter",
+		pages: []string{
+			`{"startDate":"2026-01-01T00:00:00Z","_links":{"next":{"href":"https://other.example/wrong?cursor=post-next"}}}`,
+			`{"startDate":"2026-01-02T00:00:00Z","_links":{}}`,
+			`{"startDate":"2026-01-03T00:00:00Z","_links":{}}`,
+		},
+	}
+	server := httptest.NewServer(recorder)
+	defer server.Close()
+
+	apiClient := newTestClient(server.URL, server.Client().Transport)
+	api := (*endpointtestresults.LocalNetworkEndpointTestResultsAPIService)(&apiClient.Common)
+	filter := endpointtestresults.EndpointNetworkTopologyResultRequestFilter{
+		Location:  []string{"Lisbon"},
+		NetworkId: []string{"network-1"},
+	}
+	body := endpointtestresults.EndpointNetworkTopologyResultRequest{SearchFilters: &filter}
+	request := api.FilterLocalNetworksTestResultsTopologies().
+		Aid("account").
+		Window("2h").
+		EndpointNetworkTopologyResultRequest(body)
+	pager := request.Paginated()
+	if len(recorder.calls) != 0 {
+		t.Fatal("Paginated performed a request")
+	}
+
+	for page := 1; page <= 2; page++ {
+		result, response, err := pager.NextPage(context.Background())
+		if err != nil || result == nil || result.StartDate == nil ||
+			response == nil || response.Header.Get("X-Page") != strconv.Itoa(page) {
+			t.Fatalf("page %d = (%#v, %#v, %v)", page, result, response, err)
+		}
+	}
+	page, response, err := pager.NextPage(context.Background())
+	assertCompleted(t, page, response, err)
+	assertReplay(t, recorder.calls, http.MethodPost, recorder.path, "post-next")
+	if got := recorder.calls[0].query.Encode(); got != "aid=account&window=2h" {
+		t.Fatalf("POST query = %q", got)
+	}
+
+	var firstBody, secondBody, wantBody any
+	if err := json.Unmarshal(recorder.calls[0].body, &firstBody); err != nil {
+		t.Fatalf("decode first body: %v", err)
+	}
+	if err := json.Unmarshal(recorder.calls[1].body, &secondBody); err != nil {
+		t.Fatalf("decode second body: %v", err)
+	}
+	if err := json.Unmarshal([]byte(`{"searchFilters":{"location":["Lisbon"],"networkId":["network-1"]}}`), &wantBody); err != nil {
+		t.Fatalf("decode expected body: %v", err)
+	}
+	if !reflect.DeepEqual(firstBody, secondBody) || !reflect.DeepEqual(firstBody, wantBody) ||
+		recorder.calls[0].contentType != "application/json" ||
+		recorder.calls[1].contentType != "application/json" {
+		t.Fatalf("POST body or content type changed between pages")
+	}
+	legacy, legacyHTTP, err := request.Execute()
+	if err != nil || legacy == nil || legacy.StartDate == nil || legacyHTTP == nil ||
+		legacyHTTP.Header.Get("X-Page") != "3" {
+		t.Fatalf("legacy Execute = (%#v, %#v, %v)", legacy, legacyHTTP, err)
+	}
+	assertLegacyRequest(t, recorder.calls, http.MethodPost, recorder.path)
+}
+
+func newTestClient(serverURL string, transport http.RoundTripper) *client.APIClient {
+	configuration := client.NewConfiguration().WithServerUrl(serverURL)
+	configuration.HTTPClient = &http.Client{Transport: transport}
+	return client.NewAPIClient(configuration)
+}
+
+func assertReplay(t *testing.T, calls []recordedRequest, method, path, nextCursor string) {
+	t.Helper()
+	if len(calls) != 2 {
+		t.Fatalf("requests = %d, want 2", len(calls))
+	}
+	for index := range calls {
+		if calls[index].method != method || calls[index].path != path {
+			t.Fatalf("request %d = %s %s, want %s %s", index+1, calls[index].method, calls[index].path, method, path)
+		}
+	}
+	if calls[0].query.Get("cursor") != "" || calls[1].query.Get("cursor") != nextCursor {
+		t.Fatalf("cursors = %q, %q", calls[0].query.Get("cursor"), calls[1].query.Get("cursor"))
+	}
+	calls[0].query.Del("cursor")
+	calls[1].query.Del("cursor")
+	if calls[0].query.Encode() != calls[1].query.Encode() {
+		t.Fatalf("non-cursor query changed: %q != %q", calls[0].query.Encode(), calls[1].query.Encode())
+	}
+}
+
+func assertCompleted[T any](t *testing.T, page *T, response *http.Response, err error) {
+	t.Helper()
+	if page != nil || response != nil || !errors.Is(err, io.EOF) {
+		t.Fatalf("after completion = (%#v, %#v, %v), want (nil, nil, io.EOF)", page, response, err)
+	}
+}
+
+func assertLegacyRequest(t *testing.T, calls []recordedRequest, method, path string) {
+	t.Helper()
+	if len(calls) != 3 {
+		t.Fatalf("requests after legacy Execute = %d, want 3", len(calls))
+	}
+	call := calls[2]
+	if call.method != method || call.path != path || call.query.Get("cursor") != "" {
+		t.Fatalf("legacy request = %s %s?%s", call.method, call.path, call.query.Encode())
+	}
+}

--- a/pagination/pager.go
+++ b/pagination/pager.go
@@ -1,0 +1,75 @@
+package pagination
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+// ErrInvalidContinuation indicates that a next link has no single, non-empty cursor.
+var ErrInvalidContinuation = errors.New("pagination: next link must contain exactly one non-empty cursor")
+
+// Pager fetches complete response pages on demand.
+type Pager[T any] struct {
+	cursor   *string
+	fetch    func(context.Context, *string) (*T, *http.Response, error)
+	nextHref func(*T) (string, bool)
+	complete bool
+}
+
+// NewPager creates a lazy page iterator.
+func NewPager[T any](
+	initialCursor *string,
+	fetch func(context.Context, *string) (*T, *http.Response, error),
+	nextHref func(*T) (string, bool),
+) *Pager[T] {
+	if initialCursor != nil {
+		cursor := *initialCursor
+		initialCursor = &cursor
+	}
+	return &Pager[T]{cursor: initialCursor, fetch: fetch, nextHref: nextHref}
+}
+
+// NextPage fetches one page or returns io.EOF after the final page.
+func (p *Pager[T]) NextPage(ctx context.Context) (*T, *http.Response, error) {
+	if p.complete {
+		return nil, nil, io.EOF
+	}
+
+	page, response, err := p.fetch(ctx, p.cursor)
+	if err != nil {
+		return page, response, err
+	}
+
+	href, present := p.nextHref(page)
+	if !present {
+		p.complete = true
+		return page, response, nil
+	}
+
+	cursor, err := cursorFromHref(href)
+	if err != nil {
+		return page, response, err
+	}
+	p.cursor = &cursor
+	return page, response, nil
+}
+
+func cursorFromHref(href string) (string, error) {
+	parsed, err := url.Parse(href)
+	if err != nil {
+		return "", fmt.Errorf("%w: %v", ErrInvalidContinuation, err)
+	}
+	query, err := url.ParseQuery(parsed.RawQuery)
+	if err != nil {
+		return "", fmt.Errorf("%w: %v", ErrInvalidContinuation, err)
+	}
+	cursors := query["cursor"]
+	if len(cursors) != 1 || cursors[0] == "" {
+		return "", ErrInvalidContinuation
+	}
+	return cursors[0], nil
+}

--- a/pagination/pager_test.go
+++ b/pagination/pager_test.go
@@ -1,0 +1,131 @@
+package pagination
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+type testPage struct {
+	items    []string
+	nextHref string
+}
+
+func TestPagerTraversesPagesLazily(t *testing.T) {
+	pages := []*testPage{
+		{items: []string{"first"}, nextHref: "https://other.example/wrong?cursor=second"},
+		{items: []string{"second"}},
+	}
+	responses := []*http.Response{{StatusCode: http.StatusOK}, {StatusCode: http.StatusCreated}}
+	var cursors []string
+
+	fetch := func(_ context.Context, cursor *string) (*testPage, *http.Response, error) {
+		if cursor == nil {
+			cursors = append(cursors, "")
+		} else {
+			cursors = append(cursors, *cursor)
+		}
+		index := len(cursors) - 1
+		return pages[index], responses[index], nil
+	}
+	nextHref := func(page *testPage) (string, bool) {
+		return page.nextHref, page.nextHref != ""
+	}
+
+	pager := NewPager(nil, fetch, nextHref)
+	if len(cursors) != 0 {
+		t.Fatal("NewPager fetched a page")
+	}
+
+	for index, wantPage := range pages {
+		gotPage, gotResponse, err := pager.NextPage(context.Background())
+		if err != nil {
+			t.Fatalf("NextPage(%d) error = %v", index, err)
+		}
+		if !reflect.DeepEqual(gotPage, wantPage) {
+			t.Fatalf("NextPage(%d) page = %#v, want %#v", index, gotPage, wantPage)
+		}
+		if gotResponse != responses[index] {
+			t.Fatalf("NextPage(%d) response = %p, want %p", index, gotResponse, responses[index])
+		}
+	}
+
+	if !reflect.DeepEqual(cursors, []string{"", "second"}) {
+		t.Fatalf("fetch cursors = %q, want only original cursor then next-link cursor", cursors)
+	}
+
+	gotPage, gotResponse, err := pager.NextPage(context.Background())
+	if !errors.Is(err, io.EOF) || gotPage != nil || gotResponse != nil {
+		t.Fatalf("NextPage after completion = (%#v, %#v, %v), want (nil, nil, io.EOF)", gotPage, gotResponse, err)
+	}
+	if len(cursors) != len(pages) {
+		t.Fatalf("fetch called %d times after completion, want %d", len(cursors), len(pages))
+	}
+}
+
+func TestPagerRejectsInvalidContinuation(t *testing.T) {
+	tests := map[string]string{
+		"missing":    "https://other.example/wrong?not_cursor=missing",
+		"empty":      "https://other.example/wrong?cursor=",
+		"duplicate":  "https://other.example/wrong?cursor=one&cursor=two",
+		"wrong case": "https://other.example/wrong?Cursor=next",
+	}
+
+	for name, href := range tests {
+		t.Run(name, func(t *testing.T) {
+			page := &testPage{nextHref: href}
+			pager := NewPager(
+				nil,
+				func(context.Context, *string) (*testPage, *http.Response, error) {
+					return page, &http.Response{StatusCode: http.StatusOK}, nil
+				},
+				func(page *testPage) (string, bool) { return page.nextHref, true },
+			)
+
+			if _, _, err := pager.NextPage(context.Background()); !errors.Is(err, ErrInvalidContinuation) {
+				t.Fatalf("NextPage error = %v, want ErrInvalidContinuation", err)
+			}
+		})
+	}
+}
+
+func TestPagerUsesInitialCursor(t *testing.T) {
+	initialCursor := "configured"
+	var fetchedCursor string
+	pager := NewPager(
+		&initialCursor,
+		func(_ context.Context, cursor *string) (*testPage, *http.Response, error) {
+			fetchedCursor = *cursor
+			return &testPage{}, &http.Response{StatusCode: http.StatusOK}, nil
+		},
+		func(*testPage) (string, bool) { return "", false },
+	)
+	initialCursor = "changed after construction"
+
+	if _, _, err := pager.NextPage(context.Background()); err != nil {
+		t.Fatalf("NextPage error = %v", err)
+	}
+	if fetchedCursor != "configured" {
+		t.Fatalf("fetch cursor = %q, want configured", fetchedCursor)
+	}
+}
+
+func TestPagerPreservesHTTPResponseOnFetchError(t *testing.T) {
+	wantErr := errors.New("fetch failed")
+	wantResponse := &http.Response{StatusCode: http.StatusBadGateway}
+	pager := NewPager(
+		nil,
+		func(context.Context, *string) (*testPage, *http.Response, error) {
+			return nil, wantResponse, wantErr
+		},
+		func(*testPage) (string, bool) { return "", false },
+	)
+
+	page, response, err := pager.NextPage(context.Background())
+	if page != nil || response != wantResponse || !errors.Is(err, wantErr) {
+		t.Fatalf("NextPage = (%#v, %#v, %v), want (nil, response, fetch error)", page, response, err)
+	}
+}


### PR DESCRIPTION
## Summary

- Add a lazy generic pager that returns complete pages and HTTP responses.
- Add one generated GET adapter and one generated POST adapter as integration proof.
- Preserve the original request and change only the cursor between page requests.

## What this proves

- `Paginated()` performs no network request.
- Each `NextPage(ctx)` performs one request and returns the complete page and HTTP response.
- GET query parameters and POST bodies are preserved while only `cursor` changes.
- The host and path in `_links.next.href` are ignored.
- Existing single-page `Execute()` behavior remains available.

## What this does not prove

- Full-SDK regeneration or behavior for every eligible operation.
- Compatibility with a live ThousandEyes API environment.
- Flattened item iteration equivalent to Java; this POC intentionally returns complete pages.

## Validation

- `go test ./pagination ./administrative ./endpointtestresults`
