### PR TITLE
20260728 154337

### DIFF
--- a/administrative/api_account_groups.go
+++ b/administrative/api_account_groups.go
@@ -122,41 +122,31 @@ func (a *AccountGroupsAPIService) CreateAccountGroupExecute(r ApiCreateAccountGr
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -251,41 +241,31 @@ func (a *AccountGroupsAPIService) DeleteAccountGroupExecute(r ApiDeleteAccountGr
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarHTTPResponse, newErr
+		return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	return localVarHTTPResponse, nil
@@ -379,41 +359,31 @@ func (a *AccountGroupsAPIService) GetAccountGroupExecute(r ApiGetAccountGroupReq
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -503,41 +473,31 @@ func (a *AccountGroupsAPIService) GetAccountGroupsExecute(r ApiGetAccountGroupsR
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -651,41 +611,31 @@ func (a *AccountGroupsAPIService) UpdateAccountGroupExecute(r ApiUpdateAccountGr
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -698,14 +648,4 @@ func (a *AccountGroupsAPIService) UpdateAccountGroupExecute(r ApiUpdateAccountGr
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *AccountGroupsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/administrative/api_permissions.go
+++ b/administrative/api_permissions.go
@@ -108,41 +108,31 @@ func (a *PermissionsAPIService) GetPermissionsExecute(r ApiGetPermissionsRequest
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -155,14 +145,4 @@ func (a *PermissionsAPIService) GetPermissionsExecute(r ApiGetPermissionsRequest
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *PermissionsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/administrative/api_roles.go
+++ b/administrative/api_roles.go
@@ -120,41 +120,31 @@ func (a *RolesAPIService) CreateRoleExecute(r ApiCreateRoleRequest) (*RoleDetail
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -255,41 +245,31 @@ func (a *RolesAPIService) DeleteRoleExecute(r ApiDeleteRoleRequest) (*http.Respo
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarHTTPResponse, newErr
+		return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	return localVarHTTPResponse, nil
@@ -383,41 +363,31 @@ func (a *RolesAPIService) GetRoleExecute(r ApiGetRoleRequest) (*RoleDetail, *htt
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -517,41 +487,31 @@ func (a *RolesAPIService) GetRolesExecute(r ApiGetRolesRequest) (*Roles, *http.R
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -669,41 +629,31 @@ func (a *RolesAPIService) UpdateRoleExecute(r ApiUpdateRoleRequest) (*RoleDetail
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -716,14 +666,4 @@ func (a *RolesAPIService) UpdateRoleExecute(r ApiUpdateRoleRequest) (*RoleDetail
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *RolesAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/administrative/api_user_events.go
+++ b/administrative/api_user_events.go
@@ -166,41 +166,31 @@ func (a *UserEventsAPIService) GetUserEventsExecute(r ApiGetUserEventsRequest) (
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -213,14 +203,4 @@ func (a *UserEventsAPIService) GetUserEventsExecute(r ApiGetUserEventsRequest) (
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *UserEventsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/administrative/api_users.go
+++ b/administrative/api_users.go
@@ -124,41 +124,31 @@ func (a *UsersAPIService) CreateUserExecute(r ApiCreateUserRequest) (*CreatedUse
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -259,41 +249,31 @@ func (a *UsersAPIService) DeleteUserExecute(r ApiDeleteUserRequest) (*http.Respo
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarHTTPResponse, newErr
+		return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	return localVarHTTPResponse, nil
@@ -374,41 +354,31 @@ func (a *UsersAPIService) GetCurrentUserExecute(r ApiGetCurrentUserRequest) (*Us
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -511,41 +481,31 @@ func (a *UsersAPIService) GetUserExecute(r ApiGetUserRequest) (*UserDetail, *htt
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -645,41 +605,31 @@ func (a *UsersAPIService) GetUsersExecute(r ApiGetUsersRequest) (*Users, *http.R
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -797,41 +747,31 @@ func (a *UsersAPIService) UpdateUserExecute(r ApiUpdateUserRequest) (*UserDetail
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -844,14 +784,4 @@ func (a *UsersAPIService) UpdateUserExecute(r ApiUpdateUserRequest) (*UserDetail
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *UsersAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/agents/api_agent_proxies.go
+++ b/agents/api_agent_proxies.go
@@ -109,41 +109,31 @@ func (a *AgentProxiesAPIService) GetAgentsProxiesExecute(r ApiGetAgentsProxiesRe
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -156,14 +146,4 @@ func (a *AgentProxiesAPIService) GetAgentsProxiesExecute(r ApiGetAgentsProxiesRe
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *AgentProxiesAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/agents/api_cloud_and_enterprise_agent_notification_rules.go
+++ b/agents/api_cloud_and_enterprise_agent_notification_rules.go
@@ -113,41 +113,31 @@ func (a *CloudAndEnterpriseAgentNotificationRulesAPIService) GetAgentsNotificati
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -247,41 +237,31 @@ func (a *CloudAndEnterpriseAgentNotificationRulesAPIService) GetAgentsNotificati
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -294,14 +274,4 @@ func (a *CloudAndEnterpriseAgentNotificationRulesAPIService) GetAgentsNotificati
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *CloudAndEnterpriseAgentNotificationRulesAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/agents/api_cloud_and_enterprise_agents.go
+++ b/agents/api_cloud_and_enterprise_agents.go
@@ -115,41 +115,31 @@ func (a *CloudAndEnterpriseAgentsAPIService) DeleteAgentExecute(r ApiDeleteAgent
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarHTTPResponse, newErr
+		return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	return localVarHTTPResponse, nil
@@ -256,41 +246,31 @@ func (a *CloudAndEnterpriseAgentsAPIService) GetAgentExecute(r ApiGetAgentReques
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -433,41 +413,31 @@ func (a *CloudAndEnterpriseAgentsAPIService) GetAgentsExecute(r ApiGetAgentsRequ
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -606,46 +576,35 @@ func (a *CloudAndEnterpriseAgentsAPIService) UpdateAgentExecute(r ApiUpdateAgent
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -658,14 +617,4 @@ func (a *CloudAndEnterpriseAgentsAPIService) UpdateAgentExecute(r ApiUpdateAgent
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *CloudAndEnterpriseAgentsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/agents/api_enterprise_agent_cluster.go
+++ b/agents/api_enterprise_agent_cluster.go
@@ -178,46 +178,35 @@ func (a *EnterpriseAgentClusterAPIService) AssignAgentToClusterExecute(r ApiAssi
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -372,46 +361,35 @@ func (a *EnterpriseAgentClusterAPIService) UnassignAgentFromClusterExecute(r Api
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -424,14 +402,4 @@ func (a *EnterpriseAgentClusterAPIService) UnassignAgentFromClusterExecute(r Api
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *EnterpriseAgentClusterAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/agents/api_local_problems.go
+++ b/agents/api_local_problems.go
@@ -142,46 +142,35 @@ func (a *LocalProblemsAPIService) GetAgentsLocalProblemsExecute(r ApiGetAgentsLo
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -194,14 +183,4 @@ func (a *LocalProblemsAPIService) GetAgentsLocalProblemsExecute(r ApiGetAgentsLo
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *LocalProblemsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/agents/api_tests_assignment_on_agents.go
+++ b/agents/api_tests_assignment_on_agents.go
@@ -133,46 +133,35 @@ func (a *TestsAssignmentOnAgentsAPIService) AssignTestsExecute(r ApiAssignTestsR
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -296,46 +285,35 @@ func (a *TestsAssignmentOnAgentsAPIService) OverwriteTestsExecute(r ApiOverwrite
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -455,46 +433,35 @@ func (a *TestsAssignmentOnAgentsAPIService) UnassignTestsExecute(r ApiUnassignTe
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -507,14 +474,4 @@ func (a *TestsAssignmentOnAgentsAPIService) UnassignTestsExecute(r ApiUnassignTe
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *TestsAssignmentOnAgentsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/alerts/api_alert_rules.go
+++ b/alerts/api_alert_rules.go
@@ -121,41 +121,31 @@ func (a *AlertRulesAPIService) CreateAlertRuleExecute(r ApiCreateAlertRuleReques
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -256,41 +246,31 @@ func (a *AlertRulesAPIService) DeleteAlertRuleExecute(r ApiDeleteAlertRuleReques
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarHTTPResponse, newErr
+		return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	return localVarHTTPResponse, nil
@@ -384,36 +364,27 @@ func (a *AlertRulesAPIService) GetAlertRuleExecute(r ApiGetAlertRuleRequest) (*R
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -513,36 +484,27 @@ func (a *AlertRulesAPIService) GetAlertsRulesExecute(r ApiGetAlertsRulesRequest)
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -658,41 +620,31 @@ func (a *AlertRulesAPIService) UpdateAlertRuleExecute(r ApiUpdateAlertRuleReques
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -705,14 +657,4 @@ func (a *AlertRulesAPIService) UpdateAlertRuleExecute(r ApiUpdateAlertRuleReques
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *AlertRulesAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/alerts/api_alert_suppression_windows_.go
+++ b/alerts/api_alert_suppression_windows_.go
@@ -130,41 +130,31 @@ func (a *AlertSuppressionWindowsAPIService) CreateAlertSuppressionWindowExecute(
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -265,41 +255,31 @@ func (a *AlertSuppressionWindowsAPIService) DeleteAlertSuppressionWindowExecute(
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarHTTPResponse, newErr
+		return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	return localVarHTTPResponse, nil
@@ -403,36 +383,27 @@ func (a *AlertSuppressionWindowsAPIService) GetAlertSuppressionWindowExecute(r A
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -532,36 +503,27 @@ func (a *AlertSuppressionWindowsAPIService) GetAlertSuppressionWindowsExecute(r 
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -685,41 +647,31 @@ func (a *AlertSuppressionWindowsAPIService) UpdateAlertSuppressionWindowExecute(
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -732,14 +684,4 @@ func (a *AlertSuppressionWindowsAPIService) UpdateAlertSuppressionWindowExecute(
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *AlertSuppressionWindowsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/alerts/api_alerts.go
+++ b/alerts/api_alerts.go
@@ -113,36 +113,27 @@ func (a *AlertsAPIService) GetAlertExecute(r ApiGetAlertRequest) (*AlertDetail, 
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -305,36 +296,27 @@ func (a *AlertsAPIService) GetAlertsExecute(r ApiGetAlertsRequest) (*Alerts, *ht
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -347,14 +329,4 @@ func (a *AlertsAPIService) GetAlertsExecute(r ApiGetAlertsRequest) (*Alerts, *ht
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *AlertsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/bgpmonitors/api_bgp_monitors.go
+++ b/bgpmonitors/api_bgp_monitors.go
@@ -108,36 +108,27 @@ func (a *BGPMonitorsAPIService) GetBgpMonitorsExecute(r ApiGetBgpMonitorsRequest
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -150,14 +141,4 @@ func (a *BGPMonitorsAPIService) GetBgpMonitorsExecute(r ApiGetBgpMonitorsRequest
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *BGPMonitorsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/connectors/api_credential_vault_operations.go
+++ b/connectors/api_credential_vault_operations.go
@@ -120,36 +120,27 @@ func (a *CredentialVaultOperationsAPIService) CreateCredentialVaultOperationExec
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -261,36 +252,27 @@ func (a *CredentialVaultOperationsAPIService) DeleteCredentialVaultOperationExec
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarHTTPResponse, newErr
+		return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	return localVarHTTPResponse, nil
@@ -384,36 +366,27 @@ func (a *CredentialVaultOperationsAPIService) GetCredentialVaultOperationExecute
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -513,36 +486,27 @@ func (a *CredentialVaultOperationsAPIService) GetCredentialVaultOperationsExecut
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -656,36 +620,27 @@ func (a *CredentialVaultOperationsAPIService) UpdateCredentialVaultOperationExec
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -698,14 +653,4 @@ func (a *CredentialVaultOperationsAPIService) UpdateCredentialVaultOperationExec
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *CredentialVaultOperationsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/connectors/api_cyber_ark_conjur_connectors.go
+++ b/connectors/api_cyber_ark_conjur_connectors.go
@@ -120,36 +120,27 @@ func (a *CyberArkConjurConnectorsAPIService) CreateConjurConnectorExecute(r ApiC
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -261,36 +252,27 @@ func (a *CyberArkConjurConnectorsAPIService) DeleteConjurConnectorExecute(r ApiD
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarHTTPResponse, newErr
+		return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	return localVarHTTPResponse, nil
@@ -384,36 +366,27 @@ func (a *CyberArkConjurConnectorsAPIService) GetConjurConnectorExecute(r ApiGetC
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -516,36 +489,27 @@ func (a *CyberArkConjurConnectorsAPIService) GetConjurConnectorOperationsExecute
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -645,36 +609,27 @@ func (a *CyberArkConjurConnectorsAPIService) GetConjurConnectorsExecute(r ApiGet
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -800,36 +755,27 @@ func (a *CyberArkConjurConnectorsAPIService) SetConjurConnectorOperationsExecute
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -943,36 +889,27 @@ func (a *CyberArkConjurConnectorsAPIService) UpdateConjurConnectorExecute(r ApiU
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -985,14 +922,4 @@ func (a *CyberArkConjurConnectorsAPIService) UpdateConjurConnectorExecute(r ApiU
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *CyberArkConjurConnectorsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/connectors/api_generic_connectors.go
+++ b/connectors/api_generic_connectors.go
@@ -120,36 +120,27 @@ func (a *GenericConnectorsAPIService) CreateGenericConnectorExecute(r ApiCreateG
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -250,36 +241,27 @@ func (a *GenericConnectorsAPIService) DeleteGenericConnectorExecute(r ApiDeleteG
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarHTTPResponse, newErr
+		return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	return localVarHTTPResponse, nil
@@ -373,36 +355,27 @@ func (a *GenericConnectorsAPIService) GetGenericConnectorExecute(r ApiGetGeneric
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -502,36 +475,27 @@ func (a *GenericConnectorsAPIService) GetGenericConnectorsExecute(r ApiGetGeneri
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -634,36 +598,27 @@ func (a *GenericConnectorsAPIService) ListGenericConnectorOperationsExecute(r Ap
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -778,36 +733,27 @@ func (a *GenericConnectorsAPIService) SetGenericConnectorOperationsExecute(r Api
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -921,36 +867,27 @@ func (a *GenericConnectorsAPIService) UpdateGenericConnectorExecute(r ApiUpdateG
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -963,14 +900,4 @@ func (a *GenericConnectorsAPIService) UpdateGenericConnectorExecute(r ApiUpdateG
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *GenericConnectorsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/connectors/api_operation_connectors.go
+++ b/connectors/api_operation_connectors.go
@@ -115,36 +115,27 @@ func (a *OperationConnectorsAPIService) GetOperationConnectorsExecute(r ApiGetOp
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -281,36 +272,27 @@ func (a *OperationConnectorsAPIService) SetOperationConnectorsExecute(r ApiSetOp
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -323,14 +305,4 @@ func (a *OperationConnectorsAPIService) SetOperationConnectorsExecute(r ApiSetOp
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *OperationConnectorsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/connectors/api_webhook_operations.go
+++ b/connectors/api_webhook_operations.go
@@ -120,36 +120,27 @@ func (a *WebhookOperationsAPIService) CreateWebhookOperationExecute(r ApiCreateW
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -250,36 +241,27 @@ func (a *WebhookOperationsAPIService) DeleteWebhookOperationExecute(r ApiDeleteW
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarHTTPResponse, newErr
+		return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	return localVarHTTPResponse, nil
@@ -373,36 +355,27 @@ func (a *WebhookOperationsAPIService) GetWebhookOperationExecute(r ApiGetWebhook
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -502,36 +475,27 @@ func (a *WebhookOperationsAPIService) GetWebhookOperationsExecute(r ApiGetWebhoo
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -645,36 +609,27 @@ func (a *WebhookOperationsAPIService) UpdateWebhookOperationExecute(r ApiUpdateW
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -687,14 +642,4 @@ func (a *WebhookOperationsAPIService) UpdateWebhookOperationExecute(r ApiUpdateW
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *WebhookOperationsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/credentials/api_credentials.go
+++ b/credentials/api_credentials.go
@@ -120,41 +120,31 @@ func (a *CredentialsAPIService) CreateCredentialExecute(r ApiCreateCredentialReq
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -255,36 +245,27 @@ func (a *CredentialsAPIService) DeleteCredentialExecute(r ApiDeleteCredentialReq
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarHTTPResponse, newErr
+		return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	return localVarHTTPResponse, nil
@@ -378,41 +359,31 @@ func (a *CredentialsAPIService) GetCredentialExecute(r ApiGetCredentialRequest) 
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -512,36 +483,27 @@ func (a *CredentialsAPIService) GetCredentialsExecute(r ApiGetCredentialsRequest
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -655,41 +617,31 @@ func (a *CredentialsAPIService) UpdateCredentialExecute(r ApiUpdateCredentialReq
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -702,14 +654,4 @@ func (a *CredentialsAPIService) UpdateCredentialExecute(r ApiUpdateCredentialReq
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *CredentialsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/dashboards/api_dashboard_snapshots.go
+++ b/dashboards/api_dashboard_snapshots.go
@@ -122,36 +122,27 @@ func (a *DashboardSnapshotsAPIService) CreateDashboardSnapshotExecute(r ApiCreat
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -253,41 +244,31 @@ func (a *DashboardSnapshotsAPIService) DeleteDashboardSnapshotExecute(r ApiDelet
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarHTTPResponse, newErr
+		return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	return localVarHTTPResponse, nil
@@ -381,41 +362,31 @@ func (a *DashboardSnapshotsAPIService) GetDashboardSnapshotExecute(r ApiGetDashb
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -522,41 +493,31 @@ func (a *DashboardSnapshotsAPIService) GetDashboardSnapshotWidgetDataExecute(r A
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -676,41 +637,31 @@ func (a *DashboardSnapshotsAPIService) GetDashboardSnapshotsExecute(r ApiGetDash
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -824,52 +775,32 @@ func (a *DashboardSnapshotsAPIService) UpdateDashboardSnapshotExpirationDateExec
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarHTTPResponse, newErr
+		return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	return localVarHTTPResponse, nil
-}
-
-func (a *DashboardSnapshotsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/dashboards/api_dashboards.go
+++ b/dashboards/api_dashboards.go
@@ -126,41 +126,31 @@ func (a *DashboardsAPIService) CreateDashboardExecute(r ApiCreateDashboardReques
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -266,41 +256,31 @@ func (a *DashboardsAPIService) DeleteDashboardExecute(r ApiDeleteDashboardReques
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarHTTPResponse, newErr
+		return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	return localVarHTTPResponse, nil
@@ -395,41 +375,31 @@ func (a *DashboardsAPIService) GetDashboardExecute(r ApiGetDashboardRequest) (*A
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -606,41 +576,31 @@ func (a *DashboardsAPIService) GetDashboardWidgetDataExecute(r ApiGetDashboardWi
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -741,41 +701,31 @@ func (a *DashboardsAPIService) GetDashboardsExecute(r ApiGetDashboardsRequest) (
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -915,41 +865,31 @@ func (a *DashboardsAPIService) GetIndividualCardDataExecute(r ApiGetIndividualCa
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -1089,41 +1029,31 @@ func (a *DashboardsAPIService) GetIndividualColumnDataExecute(r ApiGetIndividual
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -1243,41 +1173,31 @@ func (a *DashboardsAPIService) UpdateDashboardExecute(r ApiUpdateDashboardReques
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -1290,14 +1210,4 @@ func (a *DashboardsAPIService) UpdateDashboardExecute(r ApiUpdateDashboardReques
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *DashboardsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/dashboards/api_dashboards_filters.go
+++ b/dashboards/api_dashboards_filters.go
@@ -123,41 +123,31 @@ func (a *DashboardsFiltersAPIService) CreateDashboardFilterExecute(r ApiCreateDa
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -266,41 +256,31 @@ func (a *DashboardsFiltersAPIService) DeleteDashboardFilterExecute(r ApiDeleteDa
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarHTTPResponse, newErr
+		return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	return localVarHTTPResponse, nil
@@ -395,41 +375,31 @@ func (a *DashboardsFiltersAPIService) GetDashboardFilterExecute(r ApiGetDashboar
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -540,41 +510,31 @@ func (a *DashboardsFiltersAPIService) GetDashboardsFiltersExecute(r ApiGetDashbo
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -696,41 +656,31 @@ func (a *DashboardsFiltersAPIService) UpdateDashboardFilterExecute(r ApiUpdateDa
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -743,14 +693,4 @@ func (a *DashboardsFiltersAPIService) UpdateDashboardFilterExecute(r ApiUpdateDa
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *DashboardsFiltersAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/emulation/api_emulation.go
+++ b/emulation/api_emulation.go
@@ -119,36 +119,27 @@ func (a *EmulationAPIService) CreateEmulatedDeviceExecute(r ApiCreateEmulatedDev
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -248,36 +239,27 @@ func (a *EmulationAPIService) GetEmulatedDevicesExecute(r ApiGetEmulatedDevicesR
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -377,36 +359,27 @@ func (a *EmulationAPIService) GetUserAgentsExecute(r ApiGetUserAgentsRequest) (*
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -419,14 +392,4 @@ func (a *EmulationAPIService) GetUserAgentsExecute(r ApiGetUserAgentsRequest) (*
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *EmulationAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/endpointagents/api_endpoint_agent_log_items.go
+++ b/endpointagents/api_endpoint_agent_log_items.go
@@ -166,41 +166,31 @@ func (a *EndpointAgentLogItemsAPIService) GetEndpointAgentLogItemsExecute(r ApiG
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -213,14 +203,4 @@ func (a *EndpointAgentLogItemsAPIService) GetEndpointAgentLogItemsExecute(r ApiG
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *EndpointAgentLogItemsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/endpointagents/api_endpoint_agents.go
+++ b/endpointagents/api_endpoint_agents.go
@@ -121,31 +121,23 @@ func (a *EndpointAgentsAPIService) DeleteEndpointAgentExecute(r ApiDeleteEndpoin
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarHTTPResponse, newErr
+		return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	return localVarHTTPResponse, nil
@@ -239,31 +231,23 @@ func (a *EndpointAgentsAPIService) DisableEndpointAgentExecute(r ApiDisableEndpo
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -366,31 +350,23 @@ func (a *EndpointAgentsAPIService) EnableEndpointAgentExecute(r ApiEnableEndpoin
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -545,31 +521,23 @@ func (a *EndpointAgentsAPIService) FilterEndpointAgentsExecute(r ApiFilterEndpoi
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -692,31 +660,23 @@ func (a *EndpointAgentsAPIService) GetEndpointAgentExecute(r ApiGetEndpointAgent
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -892,26 +852,19 @@ func (a *EndpointAgentsAPIService) GetEndpointAgentsExecute(r ApiGetEndpointAgen
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -1009,26 +962,19 @@ func (a *EndpointAgentsAPIService) GetEndpointAgentsConnectionStringExecute(r Ap
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -1157,31 +1103,23 @@ func (a *EndpointAgentsAPIService) UpdateEndpointAgentExecute(r ApiUpdateEndpoin
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -1194,14 +1132,4 @@ func (a *EndpointAgentsAPIService) UpdateEndpointAgentExecute(r ApiUpdateEndpoin
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *EndpointAgentsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/endpointagents/api_endpoint_agents_transfer.go
+++ b/endpointagents/api_endpoint_agents_transfer.go
@@ -125,31 +125,23 @@ func (a *EndpointAgentsTransferAPIService) TransferEndpointAgentExecute(r ApiTra
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarHTTPResponse, newErr
+		return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	return localVarHTTPResponse, nil
@@ -260,36 +252,27 @@ func (a *EndpointAgentsTransferAPIService) TransferEndpointAgentsExecute(r ApiTr
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -302,14 +285,4 @@ func (a *EndpointAgentsTransferAPIService) TransferEndpointAgentsExecute(r ApiTr
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *EndpointAgentsTransferAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/endpointagents/api_endpoint_proxies.go
+++ b/endpointagents/api_endpoint_proxies.go
@@ -108,31 +108,23 @@ func (a *EndpointProxiesAPIService) GetEndpointProxiesExecute(r ApiGetEndpointPr
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -145,14 +137,4 @@ func (a *EndpointProxiesAPIService) GetEndpointProxiesExecute(r ApiGetEndpointPr
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *EndpointProxiesAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/endpointinstanttests/api_agent_to_server_endpoint_instant_scheduled_tests.go
+++ b/endpointinstanttests/api_agent_to_server_endpoint_instant_scheduled_tests.go
@@ -119,41 +119,31 @@ func (a *AgentToServerEndpointInstantScheduledTestsAPIService) CreateAgentToServ
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -166,14 +156,4 @@ func (a *AgentToServerEndpointInstantScheduledTestsAPIService) CreateAgentToServ
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *AgentToServerEndpointInstantScheduledTestsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/endpointinstanttests/api_http_server_endpoint_instant_scheduled_tests.go
+++ b/endpointinstanttests/api_http_server_endpoint_instant_scheduled_tests.go
@@ -119,41 +119,31 @@ func (a *HTTPServerEndpointInstantScheduledTestsAPIService) CreateHttpServerSche
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -166,14 +156,4 @@ func (a *HTTPServerEndpointInstantScheduledTestsAPIService) CreateHttpServerSche
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *HTTPServerEndpointInstantScheduledTestsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/endpointinstanttests/api_run_endpoint_instant_scheduled_tests.go
+++ b/endpointinstanttests/api_run_endpoint_instant_scheduled_tests.go
@@ -112,46 +112,35 @@ func (a *RunEndpointInstantScheduledTestsAPIService) RunEndpointScheduledInstant
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -164,14 +153,4 @@ func (a *RunEndpointInstantScheduledTestsAPIService) RunEndpointScheduledInstant
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *RunEndpointInstantScheduledTestsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/endpointlabels/api_endpoint_agent_labels.go
+++ b/endpointlabels/api_endpoint_agent_labels.go
@@ -118,31 +118,23 @@ func (a *EndpointAgentLabelsAPIService) CreateEndpointLabelExecute(r ApiCreateEn
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -244,31 +236,23 @@ func (a *EndpointAgentLabelsAPIService) DeleteEndpointLabelExecute(r ApiDeleteEn
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarHTTPResponse, newErr
+		return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	return localVarHTTPResponse, nil
@@ -372,31 +356,23 @@ func (a *EndpointAgentLabelsAPIService) GetEndpointLabelExecute(r ApiGetEndpoint
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -526,26 +502,19 @@ func (a *EndpointAgentLabelsAPIService) GetEndpointLabelsExecute(r ApiGetEndpoin
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -657,36 +626,27 @@ func (a *EndpointAgentLabelsAPIService) UpdateEndpointLabelExecute(r ApiUpdateEn
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -699,14 +659,4 @@ func (a *EndpointAgentLabelsAPIService) UpdateEndpointLabelExecute(r ApiUpdateEn
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *EndpointAgentLabelsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/endpointtestresults/api_http_server_endpoint_scheduled_test_results.go
+++ b/endpointtestresults/api_http_server_endpoint_scheduled_test_results.go
@@ -164,41 +164,31 @@ func (a *HTTPServerEndpointScheduledTestResultsAPIService) GetHttpServerSchedule
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -371,46 +361,35 @@ func (a *HTTPServerEndpointScheduledTestResultsAPIService) GetMultiTestFilteredH
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -573,46 +552,35 @@ func (a *HTTPServerEndpointScheduledTestResultsAPIService) GetSingleTestFiltered
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -625,14 +593,4 @@ func (a *HTTPServerEndpointScheduledTestResultsAPIService) GetSingleTestFiltered
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *HTTPServerEndpointScheduledTestResultsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/endpointtestresults/api_local_network_endpoint_test_results.go
+++ b/endpointtestresults/api_local_network_endpoint_test_results.go
@@ -219,46 +219,35 @@ func (a *LocalNetworkEndpointTestResultsAPIService) FilterLocalNetworksTestResul
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -361,41 +350,31 @@ func (a *LocalNetworkEndpointTestResultsAPIService) GetLocalNetworksTestResultsE
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -509,41 +488,31 @@ func (a *LocalNetworkEndpointTestResultsAPIService) GetLocalNetworksTestResultsT
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -556,14 +525,4 @@ func (a *LocalNetworkEndpointTestResultsAPIService) GetLocalNetworksTestResultsT
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *LocalNetworkEndpointTestResultsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/endpointtestresults/api_network_dynamic_endpoint_test_results.go
+++ b/endpointtestresults/api_network_dynamic_endpoint_test_results.go
@@ -173,41 +173,31 @@ func (a *NetworkDynamicEndpointTestResultsAPIService) FilterDynamicTestNetworkRe
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -317,46 +307,35 @@ func (a *NetworkDynamicEndpointTestResultsAPIService) GetDynamicTestPathVisAgent
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -500,41 +479,31 @@ func (a *NetworkDynamicEndpointTestResultsAPIService) GetDynamicTestPathVisResul
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -547,14 +516,4 @@ func (a *NetworkDynamicEndpointTestResultsAPIService) GetDynamicTestPathVisResul
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *NetworkDynamicEndpointTestResultsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/endpointtestresults/api_network_endpoint_scheduled_test_results.go
+++ b/endpointtestresults/api_network_endpoint_scheduled_test_results.go
@@ -174,41 +174,31 @@ func (a *NetworkEndpointScheduledTestResultsAPIService) FilterScheduledTestNetwo
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -392,41 +382,31 @@ func (a *NetworkEndpointScheduledTestResultsAPIService) FilterScheduledTestsNetw
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -536,41 +516,31 @@ func (a *NetworkEndpointScheduledTestResultsAPIService) GetScheduledTestPathVisA
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -714,41 +684,31 @@ func (a *NetworkEndpointScheduledTestResultsAPIService) GetScheduledTestPathVisR
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -761,14 +721,4 @@ func (a *NetworkEndpointScheduledTestResultsAPIService) GetScheduledTestPathVisR
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *NetworkEndpointScheduledTestResultsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/endpointtestresults/api_real_user_endpoint_test_results.go
+++ b/endpointtestresults/api_real_user_endpoint_test_results.go
@@ -205,46 +205,35 @@ func (a *RealUserEndpointTestResultsAPIService) FilterRealUserTestsNetworkResult
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -441,46 +430,35 @@ func (a *RealUserEndpointTestResultsAPIService) FilterRealUserTestsResultsExecut
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -675,46 +653,35 @@ func (a *RealUserEndpointTestResultsAPIService) FilterRealUserTestsVisitedPagesR
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -830,41 +797,31 @@ func (a *RealUserEndpointTestResultsAPIService) GetRealUserTestPageResultsExecut
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -968,41 +925,31 @@ func (a *RealUserEndpointTestResultsAPIService) GetRealUserTestResultsExecute(r 
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -1015,14 +962,4 @@ func (a *RealUserEndpointTestResultsAPIService) GetRealUserTestResultsExecute(r 
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *RealUserEndpointTestResultsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/endpointtests/api_agent_to_server_endpoint_dynamic_tests.go
+++ b/endpointtests/api_agent_to_server_endpoint_dynamic_tests.go
@@ -122,46 +122,35 @@ func (a *AgentToServerEndpointDynamicTestsAPIService) CreateAgentToServerEndpoin
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -262,46 +251,35 @@ func (a *AgentToServerEndpointDynamicTestsAPIService) DeleteAgentToServerEndpoin
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarHTTPResponse, newErr
+		return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	return localVarHTTPResponse, nil
@@ -395,41 +373,31 @@ func (a *AgentToServerEndpointDynamicTestsAPIService) GetAgentToServerEndpointDy
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -532,36 +500,27 @@ func (a *AgentToServerEndpointDynamicTestsAPIService) GetAgentToServerEndpointDy
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -676,46 +635,35 @@ func (a *AgentToServerEndpointDynamicTestsAPIService) UpdateAgentToServerEndpoin
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -728,14 +676,4 @@ func (a *AgentToServerEndpointDynamicTestsAPIService) UpdateAgentToServerEndpoin
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *AgentToServerEndpointDynamicTestsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/endpointtests/api_agent_to_server_endpoint_scheduled_tests.go
+++ b/endpointtests/api_agent_to_server_endpoint_scheduled_tests.go
@@ -122,46 +122,35 @@ func (a *AgentToServerEndpointScheduledTestsAPIService) CreateAgentToServerEndpo
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -262,46 +251,35 @@ func (a *AgentToServerEndpointScheduledTestsAPIService) DeleteAgentToServerEndpo
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarHTTPResponse, newErr
+		return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	return localVarHTTPResponse, nil
@@ -395,41 +373,31 @@ func (a *AgentToServerEndpointScheduledTestsAPIService) GetAgentToServerEndpoint
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -532,36 +500,27 @@ func (a *AgentToServerEndpointScheduledTestsAPIService) GetAgentToServerEndpoint
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -676,46 +635,35 @@ func (a *AgentToServerEndpointScheduledTestsAPIService) UpdateAgentToServerEndpo
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -728,14 +676,4 @@ func (a *AgentToServerEndpointScheduledTestsAPIService) UpdateAgentToServerEndpo
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *AgentToServerEndpointScheduledTestsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/endpointtests/api_endpoint_real_user_tests.go
+++ b/endpointtests/api_endpoint_real_user_tests.go
@@ -108,31 +108,23 @@ func (a *EndpointRealUserTestsAPIService) GetEndpointRealUserTestsExecute(r ApiG
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -145,14 +137,4 @@ func (a *EndpointRealUserTestsAPIService) GetEndpointRealUserTestsExecute(r ApiG
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *EndpointRealUserTestsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/endpointtests/api_endpoint_scheduled_tests.go
+++ b/endpointtests/api_endpoint_scheduled_tests.go
@@ -111,36 +111,27 @@ func (a *EndpointScheduledTestsAPIService) GetEndpointScheduledTestsExecute(r Ap
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -153,14 +144,4 @@ func (a *EndpointScheduledTestsAPIService) GetEndpointScheduledTestsExecute(r Ap
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *EndpointScheduledTestsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/endpointtests/api_http_server_endpoint_scheduled_tests.go
+++ b/endpointtests/api_http_server_endpoint_scheduled_tests.go
@@ -122,46 +122,35 @@ func (a *HTTPServerEndpointScheduledTestsAPIService) CreateHttpServerEndpointSch
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -262,46 +251,35 @@ func (a *HTTPServerEndpointScheduledTestsAPIService) DeleteHttpServerEndpointSch
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarHTTPResponse, newErr
+		return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	return localVarHTTPResponse, nil
@@ -395,41 +373,31 @@ func (a *HTTPServerEndpointScheduledTestsAPIService) GetHttpServerEndpointSchedu
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -532,36 +500,27 @@ func (a *HTTPServerEndpointScheduledTestsAPIService) GetHttpServerEndpointSchedu
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -676,46 +635,35 @@ func (a *HTTPServerEndpointScheduledTestsAPIService) UpdateHttpServerEndpointSch
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -728,14 +676,4 @@ func (a *HTTPServerEndpointScheduledTestsAPIService) UpdateHttpServerEndpointSch
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *HTTPServerEndpointScheduledTestsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/eventdetection/api_events.go
+++ b/eventdetection/api_events.go
@@ -113,41 +113,31 @@ func (a *EventsAPIService) GetEventExecute(r ApiGetEventRequest) (*EventDetail, 
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -307,46 +297,35 @@ func (a *EventsAPIService) GetEventsExecute(r ApiGetEventsRequest) (*Events, *ht
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -359,14 +338,4 @@ func (a *EventsAPIService) GetEventsExecute(r ApiGetEventsRequest) (*Events, *ht
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *EventsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/instanttests/api_agent_to_agent_instant_tests.go
+++ b/instanttests/api_agent_to_agent_instant_tests.go
@@ -129,46 +129,35 @@ func (a *AgentToAgentInstantTestsAPIService) CreateAgentToAgentInstantTestExecut
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -181,14 +170,4 @@ func (a *AgentToAgentInstantTestsAPIService) CreateAgentToAgentInstantTestExecut
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *AgentToAgentInstantTestsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/instanttests/api_agent_to_server_instant_tests.go
+++ b/instanttests/api_agent_to_server_instant_tests.go
@@ -129,46 +129,35 @@ func (a *AgentToServerInstantTestsAPIService) CreateAgentToServerInstantTestExec
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -181,14 +170,4 @@ func (a *AgentToServerInstantTestsAPIService) CreateAgentToServerInstantTestExec
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *AgentToServerInstantTestsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/instanttests/api_api_instant_tests.go
+++ b/instanttests/api_api_instant_tests.go
@@ -129,46 +129,35 @@ func (a *APIInstantTestsAPIService) CreateApiInstantTestExecute(r ApiCreateApiIn
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -181,14 +170,4 @@ func (a *APIInstantTestsAPIService) CreateApiInstantTestExecute(r ApiCreateApiIn
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *APIInstantTestsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/instanttests/api_dns_server_instant_tests.go
+++ b/instanttests/api_dns_server_instant_tests.go
@@ -129,46 +129,35 @@ func (a *DNSServerInstantTestsAPIService) CreateDnsServerInstantTestExecute(r Ap
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -181,14 +170,4 @@ func (a *DNSServerInstantTestsAPIService) CreateDnsServerInstantTestExecute(r Ap
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *DNSServerInstantTestsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/instanttests/api_dns_trace_instant_tests.go
+++ b/instanttests/api_dns_trace_instant_tests.go
@@ -129,46 +129,35 @@ func (a *DNSTraceInstantTestsAPIService) CreateDnsTraceInstantTestExecute(r ApiC
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -181,14 +170,4 @@ func (a *DNSTraceInstantTestsAPIService) CreateDnsTraceInstantTestExecute(r ApiC
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *DNSTraceInstantTestsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/instanttests/api_dnssec_instant_tests.go
+++ b/instanttests/api_dnssec_instant_tests.go
@@ -129,46 +129,35 @@ func (a *DNSSECInstantTestsAPIService) CreateDnsSecInstantTestExecute(r ApiCreat
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -181,14 +170,4 @@ func (a *DNSSECInstantTestsAPIService) CreateDnsSecInstantTestExecute(r ApiCreat
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *DNSSECInstantTestsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/instanttests/api_ftp_server_instant_tests.go
+++ b/instanttests/api_ftp_server_instant_tests.go
@@ -129,46 +129,35 @@ func (a *FTPServerInstantTestsAPIService) CreateFtpServerInstantTestExecute(r Ap
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -181,14 +170,4 @@ func (a *FTPServerInstantTestsAPIService) CreateFtpServerInstantTestExecute(r Ap
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *FTPServerInstantTestsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/instanttests/api_http_page_load_instant_tests.go
+++ b/instanttests/api_http_page_load_instant_tests.go
@@ -129,46 +129,35 @@ func (a *HTTPPageLoadInstantTestsAPIService) CreatePageLoadInstantTestExecute(r 
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -181,14 +170,4 @@ func (a *HTTPPageLoadInstantTestsAPIService) CreatePageLoadInstantTestExecute(r 
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *HTTPPageLoadInstantTestsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/instanttests/api_http_server_instant_tests.go
+++ b/instanttests/api_http_server_instant_tests.go
@@ -129,46 +129,35 @@ func (a *HTTPServerInstantTestsAPIService) CreateHttpServerInstantTestExecute(r 
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -181,14 +170,4 @@ func (a *HTTPServerInstantTestsAPIService) CreateHttpServerInstantTestExecute(r 
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *HTTPServerInstantTestsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/instanttests/api_instant_tests.go
+++ b/instanttests/api_instant_tests.go
@@ -110,52 +110,32 @@ func (a *InstantTestsAPIService) RunInstantTestExecute(r ApiRunInstantTestReques
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarHTTPResponse, newErr
+		return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	return localVarHTTPResponse, nil
-}
-
-func (a *InstantTestsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/instanttests/api_sip_server_instant_tests.go
+++ b/instanttests/api_sip_server_instant_tests.go
@@ -129,46 +129,35 @@ func (a *SIPServerInstantTestsAPIService) CreateSipServerInstantTestExecute(r Ap
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -181,14 +170,4 @@ func (a *SIPServerInstantTestsAPIService) CreateSipServerInstantTestExecute(r Ap
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *SIPServerInstantTestsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/instanttests/api_voice_instant_tests.go
+++ b/instanttests/api_voice_instant_tests.go
@@ -129,46 +129,35 @@ func (a *VoiceInstantTestsAPIService) CreateVoiceInstantTestExecute(r ApiCreateV
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -181,14 +170,4 @@ func (a *VoiceInstantTestsAPIService) CreateVoiceInstantTestExecute(r ApiCreateV
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *VoiceInstantTestsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/instanttests/api_web_transaction_instant_tests.go
+++ b/instanttests/api_web_transaction_instant_tests.go
@@ -129,46 +129,35 @@ func (a *WebTransactionInstantTestsAPIService) CreateWebTransactionInstantTestEx
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -181,14 +170,4 @@ func (a *WebTransactionInstantTestsAPIService) CreateWebTransactionInstantTestEx
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *WebTransactionInstantTestsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/internetinsights/api_internet_insights_catalog_providers.go
+++ b/internetinsights/api_internet_insights_catalog_providers.go
@@ -123,46 +123,35 @@ func (a *InternetInsightsCatalogProvidersAPIService) FilterCatalogProvidersExecu
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -266,46 +255,35 @@ func (a *InternetInsightsCatalogProvidersAPIService) GetCatalogProviderExecute(r
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -318,14 +296,4 @@ func (a *InternetInsightsCatalogProvidersAPIService) GetCatalogProviderExecute(r
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *InternetInsightsCatalogProvidersAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/internetinsights/api_internet_insights_outages.go
+++ b/internetinsights/api_internet_insights_outages.go
@@ -206,46 +206,35 @@ func (a *InternetInsightsOutagesAPIService) FilterOutagesExecute(r ApiFilterOuta
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -349,46 +338,35 @@ func (a *InternetInsightsOutagesAPIService) GetAppOutageExecute(r ApiGetAppOutag
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -492,46 +470,35 @@ func (a *InternetInsightsOutagesAPIService) GetNetworkOutageExecute(r ApiGetNetw
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -544,14 +511,4 @@ func (a *InternetInsightsOutagesAPIService) GetNetworkOutageExecute(r ApiGetNetw
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *InternetInsightsOutagesAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/snapshots/api_test_snapshots.go
+++ b/snapshots/api_test_snapshots.go
@@ -133,46 +133,35 @@ func (a *TestSnapshotsAPIService) CreateTestSnapshotExecute(r ApiCreateTestSnaps
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -185,14 +174,4 @@ func (a *TestSnapshotsAPIService) CreateTestSnapshotExecute(r ApiCreateTestSnaps
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *TestSnapshotsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/streaming/api_streaming.go
+++ b/streaming/api_streaming.go
@@ -118,31 +118,23 @@ func (a *StreamingAPIService) CreateStreamExecute(r ApiCreateStreamRequest) (*Cr
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v BadRequestError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 412 {
 			var v ApiErrorIntegrationLimits
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v ApiError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -243,21 +235,15 @@ func (a *StreamingAPIService) DeleteStreamExecute(r ApiDeleteStreamRequest) (*ht
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v ApiError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarHTTPResponse, newErr
+		return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	return localVarHTTPResponse, nil
@@ -361,21 +347,15 @@ func (a *StreamingAPIService) GetStreamExecute(r ApiGetStreamRequest) (*GetStrea
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v ApiError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -485,26 +465,19 @@ func (a *StreamingAPIService) GetStreamsExecute(r ApiGetStreamsRequest) ([]GetSt
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v BadRequestError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v ApiError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -615,26 +588,19 @@ func (a *StreamingAPIService) UpdateStreamExecute(r ApiUpdateStreamRequest) (*Ge
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v BadRequestError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v ApiError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -647,14 +613,4 @@ func (a *StreamingAPIService) UpdateStreamExecute(r ApiUpdateStreamRequest) (*Ge
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *StreamingAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/tags/api_tag_assignment.go
+++ b/tags/api_tag_assignment.go
@@ -123,36 +123,27 @@ func (a *TagAssignmentAPIService) AssignTagExecute(r ApiAssignTagRequest) (*Bulk
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v ApiError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -263,36 +254,27 @@ func (a *TagAssignmentAPIService) AssignTagsExecute(r ApiAssignTagsRequest) (*Bu
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v ApiError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -404,36 +386,27 @@ func (a *TagAssignmentAPIService) UnassignTagExecute(r ApiUnassignTagRequest) (*
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v ApiError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarHTTPResponse, newErr
+		return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	return localVarHTTPResponse, nil
@@ -535,36 +508,27 @@ func (a *TagAssignmentAPIService) UnassignTagsExecute(r ApiUnassignTagsRequest) 
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v ApiError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -577,14 +541,4 @@ func (a *TagAssignmentAPIService) UnassignTagsExecute(r ApiUnassignTagsRequest) 
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *TagAssignmentAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/tags/api_tags.go
+++ b/tags/api_tags.go
@@ -119,26 +119,19 @@ func (a *TagsAPIService) CreateTagExecute(r ApiCreateTagRequest) (*Tag, *http.Re
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v ApiError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -247,26 +240,19 @@ func (a *TagsAPIService) CreateTagsExecute(r ApiCreateTagsRequest) (*BulkTagResp
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v ApiError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -367,36 +353,27 @@ func (a *TagsAPIService) DeleteTagExecute(r ApiDeleteTagRequest) (*http.Response
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v ApiError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarHTTPResponse, newErr
+		return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	return localVarHTTPResponse, nil
@@ -508,36 +485,27 @@ func (a *TagsAPIService) GetTagExecute(r ApiGetTagRequest) (*Tag, *http.Response
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v ApiError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -655,36 +623,27 @@ func (a *TagsAPIService) GetTagsExecute(r ApiGetTagsRequest) (*Tags, *http.Respo
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v ApiError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -795,36 +754,27 @@ func (a *TagsAPIService) UpdateTagExecute(r ApiUpdateTagRequest) (*Tag, *http.Re
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v ApiError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -837,14 +787,4 @@ func (a *TagsAPIService) UpdateTagExecute(r ApiUpdateTagRequest) (*Tag, *http.Re
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *TagsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/testresults/api_api_test_results.go
+++ b/testresults/api_api_test_results.go
@@ -120,46 +120,35 @@ func (a *APITestResultsAPIService) GetTestApiAgentRoundResultsExecute(r ApiGetTe
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -303,46 +292,35 @@ func (a *APITestResultsAPIService) GetTestApiResultsExecute(r ApiGetTestApiResul
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -355,14 +333,4 @@ func (a *APITestResultsAPIService) GetTestApiResultsExecute(r ApiGetTestApiResul
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *APITestResultsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/testresults/api_dns_server_test_results.go
+++ b/testresults/api_dns_server_test_results.go
@@ -157,46 +157,35 @@ func (a *DNSServerTestResultsAPIService) GetTestDnsServerResultExecute(r ApiGetT
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -340,46 +329,35 @@ func (a *DNSServerTestResultsAPIService) GetTestDnsServersResultsExecute(r ApiGe
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -392,14 +370,4 @@ func (a *DNSServerTestResultsAPIService) GetTestDnsServersResultsExecute(r ApiGe
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *DNSServerTestResultsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/testresults/api_dns_trace_test_results.go
+++ b/testresults/api_dns_trace_test_results.go
@@ -154,46 +154,35 @@ func (a *DNSTraceTestResultsAPIService) GetTestDnsTraceResultsExecute(r ApiGetTe
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -206,14 +195,4 @@ func (a *DNSTraceTestResultsAPIService) GetTestDnsTraceResultsExecute(r ApiGetTe
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *DNSTraceTestResultsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/testresults/api_dnssec_test_results.go
+++ b/testresults/api_dnssec_test_results.go
@@ -154,46 +154,35 @@ func (a *DNSSECTestResultsAPIService) GetTestDnsSecResultsExecute(r ApiGetTestDn
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -206,14 +195,4 @@ func (a *DNSSECTestResultsAPIService) GetTestDnsSecResultsExecute(r ApiGetTestDn
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *DNSSECTestResultsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/testresults/api_network_bgp_test_results.go
+++ b/testresults/api_network_bgp_test_results.go
@@ -154,46 +154,35 @@ func (a *NetworkBGPTestResultsAPIService) GetTestBgpResultsExecute(r ApiGetTestB
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -303,46 +292,35 @@ func (a *NetworkBGPTestResultsAPIService) GetTestBgpRoutesPrefixRoundResultsExec
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -355,14 +333,4 @@ func (a *NetworkBGPTestResultsAPIService) GetTestBgpRoutesPrefixRoundResultsExec
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *NetworkBGPTestResultsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/testresults/api_network_test_results.go
+++ b/testresults/api_network_test_results.go
@@ -167,46 +167,35 @@ func (a *NetworkTestResultsAPIService) GetTestNetworkResultsExecute(r ApiGetTest
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -328,46 +317,35 @@ func (a *NetworkTestResultsAPIService) GetTestPathVisAgentRoundResultsExecute(r 
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -523,46 +501,35 @@ func (a *NetworkTestResultsAPIService) GetTestPathVisResultsExecute(r ApiGetTest
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -575,14 +542,4 @@ func (a *NetworkTestResultsAPIService) GetTestPathVisResultsExecute(r ApiGetTest
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *NetworkTestResultsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/testresults/api_voice_rtp_server_test_results.go
+++ b/testresults/api_voice_rtp_server_test_results.go
@@ -154,46 +154,35 @@ func (a *VoiceRTPServerTestResultsAPIService) GetTestRtpServerResultsExecute(r A
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -206,14 +195,4 @@ func (a *VoiceRTPServerTestResultsAPIService) GetTestRtpServerResultsExecute(r A
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *VoiceRTPServerTestResultsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/testresults/api_voice_sip_server_test_results.go
+++ b/testresults/api_voice_sip_server_test_results.go
@@ -154,46 +154,35 @@ func (a *VoiceSIPServerTestResultsAPIService) GetTestSipServerResultsExecute(r A
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -206,14 +195,4 @@ func (a *VoiceSIPServerTestResultsAPIService) GetTestSipServerResultsExecute(r A
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *VoiceSIPServerTestResultsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/testresults/api_web_ftp_server_test_results.go
+++ b/testresults/api_web_ftp_server_test_results.go
@@ -154,46 +154,35 @@ func (a *WebFTPServerTestResultsAPIService) GetTestFtpServerResultsExecute(r Api
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -206,14 +195,4 @@ func (a *WebFTPServerTestResultsAPIService) GetTestFtpServerResultsExecute(r Api
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *WebFTPServerTestResultsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/testresults/api_web_http_server_test_results.go
+++ b/testresults/api_web_http_server_test_results.go
@@ -168,46 +168,35 @@ func (a *WebHTTPServerTestResultsAPIService) GetTestHttpServerResultsExecute(r A
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -220,14 +209,4 @@ func (a *WebHTTPServerTestResultsAPIService) GetTestHttpServerResultsExecute(r A
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *WebHTTPServerTestResultsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/testresults/api_web_page_load_test_results.go
+++ b/testresults/api_web_page_load_test_results.go
@@ -120,46 +120,35 @@ func (a *WebPageLoadTestResultsAPIService) GetTestPageLoadAgentRoundResultsExecu
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -303,46 +292,35 @@ func (a *WebPageLoadTestResultsAPIService) GetTestPageLoadResultsExecute(r ApiGe
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -355,14 +333,4 @@ func (a *WebPageLoadTestResultsAPIService) GetTestPageLoadResultsExecute(r ApiGe
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *WebPageLoadTestResultsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/testresults/api_web_transactions_test_results.go
+++ b/testresults/api_web_transactions_test_results.go
@@ -123,46 +123,35 @@ func (a *WebTransactionsTestResultsAPIService) GetTestWebTransactionAgentRoundPa
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -272,46 +261,35 @@ func (a *WebTransactionsTestResultsAPIService) GetTestWebTransactionAgentRoundRe
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -455,46 +433,35 @@ func (a *WebTransactionsTestResultsAPIService) GetTestWebTransactionResultsExecu
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -507,14 +474,4 @@ func (a *WebTransactionsTestResultsAPIService) GetTestWebTransactionResultsExecu
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *WebTransactionsTestResultsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/tests/api_agent_to_agent_tests.go
+++ b/tests/api_agent_to_agent_tests.go
@@ -130,46 +130,35 @@ func (a *AgentToAgentTestsAPIService) CreateAgentToAgentTestExecute(r ApiCreateA
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -270,41 +259,31 @@ func (a *AgentToAgentTestsAPIService) DeleteAgentToAgentTestExecute(r ApiDeleteA
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarHTTPResponse, newErr
+		return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	return localVarHTTPResponse, nil
@@ -418,41 +397,31 @@ func (a *AgentToAgentTestsAPIService) GetAgentToAgentTestExecute(r ApiGetAgentTo
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -555,41 +524,31 @@ func (a *AgentToAgentTestsAPIService) GetAgentToAgentTestsExecute(r ApiGetAgentT
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -713,46 +672,35 @@ func (a *AgentToAgentTestsAPIService) UpdateAgentToAgentTestExecute(r ApiUpdateA
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -765,14 +713,4 @@ func (a *AgentToAgentTestsAPIService) UpdateAgentToAgentTestExecute(r ApiUpdateA
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *AgentToAgentTestsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/tests/api_agent_to_server_tests.go
+++ b/tests/api_agent_to_server_tests.go
@@ -130,46 +130,35 @@ func (a *AgentToServerTestsAPIService) CreateAgentToServerTestExecute(r ApiCreat
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -270,41 +259,31 @@ func (a *AgentToServerTestsAPIService) DeleteAgentToServerTestExecute(r ApiDelet
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarHTTPResponse, newErr
+		return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	return localVarHTTPResponse, nil
@@ -418,41 +397,31 @@ func (a *AgentToServerTestsAPIService) GetAgentToServerTestExecute(r ApiGetAgent
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -555,41 +524,31 @@ func (a *AgentToServerTestsAPIService) GetAgentToServerTestsExecute(r ApiGetAgen
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -713,46 +672,35 @@ func (a *AgentToServerTestsAPIService) UpdateAgentToServerTestExecute(r ApiUpdat
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -765,14 +713,4 @@ func (a *AgentToServerTestsAPIService) UpdateAgentToServerTestExecute(r ApiUpdat
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *AgentToServerTestsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/tests/api_api_tests.go
+++ b/tests/api_api_tests.go
@@ -130,46 +130,35 @@ func (a *APITestsAPIService) CreateApiTestExecute(r ApiCreateApiTestRequest) (*A
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -270,41 +259,31 @@ func (a *APITestsAPIService) DeleteApiTestExecute(r ApiDeleteApiTestRequest) (*h
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarHTTPResponse, newErr
+		return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	return localVarHTTPResponse, nil
@@ -418,41 +397,31 @@ func (a *APITestsAPIService) GetApiTestExecute(r ApiGetApiTestRequest) (*ApiTest
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -555,41 +524,31 @@ func (a *APITestsAPIService) GetApiTestsExecute(r ApiGetApiTestsRequest) (*ApiTe
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -714,46 +673,35 @@ func (a *APITestsAPIService) UpdateApiTestExecute(r ApiUpdateApiTestRequest) (*A
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -766,14 +714,4 @@ func (a *APITestsAPIService) UpdateApiTestExecute(r ApiUpdateApiTestRequest) (*A
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *APITestsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/tests/api_bgp_tests.go
+++ b/tests/api_bgp_tests.go
@@ -130,46 +130,35 @@ func (a *BGPTestsAPIService) CreateBgpTestExecute(r ApiCreateBgpTestRequest) (*B
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -270,41 +259,31 @@ func (a *BGPTestsAPIService) DeleteBgpTestExecute(r ApiDeleteBgpTestRequest) (*h
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarHTTPResponse, newErr
+		return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	return localVarHTTPResponse, nil
@@ -408,41 +387,31 @@ func (a *BGPTestsAPIService) GetBgpTestExecute(r ApiGetBgpTestRequest) (*BgpTest
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -545,41 +514,31 @@ func (a *BGPTestsAPIService) GetBgpTestsExecute(r ApiGetBgpTestsRequest) (*BgpTe
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -704,46 +663,35 @@ func (a *BGPTestsAPIService) UpdateBgpTestExecute(r ApiUpdateBgpTestRequest) (*B
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -756,14 +704,4 @@ func (a *BGPTestsAPIService) UpdateBgpTestExecute(r ApiUpdateBgpTestRequest) (*B
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *BGPTestsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/tests/api_dns_server_tests.go
+++ b/tests/api_dns_server_tests.go
@@ -130,46 +130,35 @@ func (a *DNSServerTestsAPIService) CreateDnsServerTestExecute(r ApiCreateDnsServ
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -270,41 +259,31 @@ func (a *DNSServerTestsAPIService) DeleteDnsServerTestExecute(r ApiDeleteDnsServ
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarHTTPResponse, newErr
+		return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	return localVarHTTPResponse, nil
@@ -418,41 +397,31 @@ func (a *DNSServerTestsAPIService) GetDnsServerTestExecute(r ApiGetDnsServerTest
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -555,41 +524,31 @@ func (a *DNSServerTestsAPIService) GetDnsServerTestsExecute(r ApiGetDnsServerTes
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -714,46 +673,35 @@ func (a *DNSServerTestsAPIService) UpdateDnsServerTestExecute(r ApiUpdateDnsServ
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -766,14 +714,4 @@ func (a *DNSServerTestsAPIService) UpdateDnsServerTestExecute(r ApiUpdateDnsServ
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *DNSServerTestsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/tests/api_dns_trace_tests.go
+++ b/tests/api_dns_trace_tests.go
@@ -130,46 +130,35 @@ func (a *DNSTraceTestsAPIService) CreateDnsTraceTestExecute(r ApiCreateDnsTraceT
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -270,41 +259,31 @@ func (a *DNSTraceTestsAPIService) DeleteDnsTraceTestExecute(r ApiDeleteDnsTraceT
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarHTTPResponse, newErr
+		return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	return localVarHTTPResponse, nil
@@ -418,41 +397,31 @@ func (a *DNSTraceTestsAPIService) GetDnsTraceTestExecute(r ApiGetDnsTraceTestReq
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -555,41 +524,31 @@ func (a *DNSTraceTestsAPIService) GetDnsTraceTestsExecute(r ApiGetDnsTraceTestsR
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -714,46 +673,35 @@ func (a *DNSTraceTestsAPIService) UpdateDnsTraceTestExecute(r ApiUpdateDnsTraceT
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -766,14 +714,4 @@ func (a *DNSTraceTestsAPIService) UpdateDnsTraceTestExecute(r ApiUpdateDnsTraceT
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *DNSTraceTestsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/tests/api_dnssec_tests.go
+++ b/tests/api_dnssec_tests.go
@@ -130,46 +130,35 @@ func (a *DNSSECTestsAPIService) CreateDnsSecTestExecute(r ApiCreateDnsSecTestReq
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -270,41 +259,31 @@ func (a *DNSSECTestsAPIService) DeleteDnsSecTestExecute(r ApiDeleteDnsSecTestReq
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarHTTPResponse, newErr
+		return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	return localVarHTTPResponse, nil
@@ -418,41 +397,31 @@ func (a *DNSSECTestsAPIService) GetDnsSecTestExecute(r ApiGetDnsSecTestRequest) 
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -555,41 +524,31 @@ func (a *DNSSECTestsAPIService) GetDnsSecTestsExecute(r ApiGetDnsSecTestsRequest
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -714,46 +673,35 @@ func (a *DNSSECTestsAPIService) UpdateDnsSecTestExecute(r ApiUpdateDnsSecTestReq
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -766,14 +714,4 @@ func (a *DNSSECTestsAPIService) UpdateDnsSecTestExecute(r ApiUpdateDnsSecTestReq
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *DNSSECTestsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/tests/api_ftp_server_tests.go
+++ b/tests/api_ftp_server_tests.go
@@ -130,46 +130,35 @@ func (a *FTPServerTestsAPIService) CreateFtpServerTestExecute(r ApiCreateFtpServ
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -270,36 +259,27 @@ func (a *FTPServerTestsAPIService) DeleteFtpServerTestExecute(r ApiDeleteFtpServ
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarHTTPResponse, newErr
+		return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	return localVarHTTPResponse, nil
@@ -413,41 +393,31 @@ func (a *FTPServerTestsAPIService) GetFtpServerTestExecute(r ApiGetFtpServerTest
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -550,41 +520,31 @@ func (a *FTPServerTestsAPIService) GetFtpServerTestsExecute(r ApiGetFtpServerTes
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -709,46 +669,35 @@ func (a *FTPServerTestsAPIService) UpdateFtpServerTestExecute(r ApiUpdateFtpServ
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -761,14 +710,4 @@ func (a *FTPServerTestsAPIService) UpdateFtpServerTestExecute(r ApiUpdateFtpServ
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *FTPServerTestsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/tests/api_http_server_tests.go
+++ b/tests/api_http_server_tests.go
@@ -130,46 +130,35 @@ func (a *HTTPServerTestsAPIService) CreateHttpServerTestExecute(r ApiCreateHttpS
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -270,41 +259,31 @@ func (a *HTTPServerTestsAPIService) DeleteHttpServerTestExecute(r ApiDeleteHttpS
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarHTTPResponse, newErr
+		return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	return localVarHTTPResponse, nil
@@ -418,41 +397,31 @@ func (a *HTTPServerTestsAPIService) GetHttpServerTestExecute(r ApiGetHttpServerT
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -555,41 +524,31 @@ func (a *HTTPServerTestsAPIService) GetHttpServerTestsExecute(r ApiGetHttpServer
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -714,46 +673,35 @@ func (a *HTTPServerTestsAPIService) UpdateHttpServerTestExecute(r ApiUpdateHttpS
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -766,14 +714,4 @@ func (a *HTTPServerTestsAPIService) UpdateHttpServerTestExecute(r ApiUpdateHttpS
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *HTTPServerTestsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/tests/api_page_load_tests.go
+++ b/tests/api_page_load_tests.go
@@ -130,46 +130,35 @@ func (a *PageLoadTestsAPIService) CreatePageLoadTestExecute(r ApiCreatePageLoadT
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -270,41 +259,31 @@ func (a *PageLoadTestsAPIService) DeletePageLoadTestExecute(r ApiDeletePageLoadT
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarHTTPResponse, newErr
+		return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	return localVarHTTPResponse, nil
@@ -418,41 +397,31 @@ func (a *PageLoadTestsAPIService) GetPageLoadTestExecute(r ApiGetPageLoadTestReq
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -555,41 +524,31 @@ func (a *PageLoadTestsAPIService) GetPageLoadTestsExecute(r ApiGetPageLoadTestsR
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -714,46 +673,35 @@ func (a *PageLoadTestsAPIService) UpdatePageLoadTestExecute(r ApiUpdatePageLoadT
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -766,14 +714,4 @@ func (a *PageLoadTestsAPIService) UpdatePageLoadTestExecute(r ApiUpdatePageLoadT
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *PageLoadTestsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/tests/api_path_visualization_interface_groups.go
+++ b/tests/api_path_visualization_interface_groups.go
@@ -120,46 +120,35 @@ func (a *PathVisualizationInterfaceGroupsAPIService) CreatePathVisInterfaceGroup
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -260,41 +249,31 @@ func (a *PathVisualizationInterfaceGroupsAPIService) DeletePathVisInterfaceGroup
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarHTTPResponse, newErr
+		return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	return localVarHTTPResponse, nil
@@ -385,41 +364,31 @@ func (a *PathVisualizationInterfaceGroupsAPIService) GetPathVisInterfaceGroupsEx
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -533,46 +502,35 @@ func (a *PathVisualizationInterfaceGroupsAPIService) UpdatePathVisInterfaceGroup
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -585,14 +543,4 @@ func (a *PathVisualizationInterfaceGroupsAPIService) UpdatePathVisInterfaceGroup
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *PathVisualizationInterfaceGroupsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/tests/api_sip_server_tests.go
+++ b/tests/api_sip_server_tests.go
@@ -130,46 +130,35 @@ func (a *SIPServerTestsAPIService) CreateSipServerTestExecute(r ApiCreateSipServ
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -270,36 +259,27 @@ func (a *SIPServerTestsAPIService) DeleteSipServerTestExecute(r ApiDeleteSipServ
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarHTTPResponse, newErr
+		return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	return localVarHTTPResponse, nil
@@ -413,41 +393,31 @@ func (a *SIPServerTestsAPIService) GetSipServerTestExecute(r ApiGetSipServerTest
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -550,41 +520,31 @@ func (a *SIPServerTestsAPIService) GetSipServerTestsExecute(r ApiGetSipServerTes
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -709,46 +669,35 @@ func (a *SIPServerTestsAPIService) UpdateSipServerTestExecute(r ApiUpdateSipServ
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -761,14 +710,4 @@ func (a *SIPServerTestsAPIService) UpdateSipServerTestExecute(r ApiUpdateSipServ
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *SIPServerTestsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/tests/api_tests.go
+++ b/tests/api_tests.go
@@ -125,31 +125,23 @@ func (a *TestsAPIService) GetTestVersionHistoryExecute(r ApiGetTestVersionHistor
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -252,41 +244,31 @@ func (a *TestsAPIService) GetTestsExecute(r ApiGetTestsRequest) (*Tests, *http.R
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -299,14 +281,4 @@ func (a *TestsAPIService) GetTestsExecute(r ApiGetTestsRequest) (*Tests, *http.R
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *TestsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/tests/api_voice_tests.go
+++ b/tests/api_voice_tests.go
@@ -130,46 +130,35 @@ func (a *VoiceTestsAPIService) CreateVoiceTestExecute(r ApiCreateVoiceTestReques
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -270,41 +259,31 @@ func (a *VoiceTestsAPIService) DeleteVoiceTestExecute(r ApiDeleteVoiceTestReques
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarHTTPResponse, newErr
+		return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	return localVarHTTPResponse, nil
@@ -418,41 +397,31 @@ func (a *VoiceTestsAPIService) GetVoiceTestExecute(r ApiGetVoiceTestRequest) (*V
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -555,41 +524,31 @@ func (a *VoiceTestsAPIService) GetVoiceTestsExecute(r ApiGetVoiceTestsRequest) (
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -714,46 +673,35 @@ func (a *VoiceTestsAPIService) UpdateVoiceTestExecute(r ApiUpdateVoiceTestReques
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -766,14 +714,4 @@ func (a *VoiceTestsAPIService) UpdateVoiceTestExecute(r ApiUpdateVoiceTestReques
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *VoiceTestsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/tests/api_web_transaction_tests.go
+++ b/tests/api_web_transaction_tests.go
@@ -130,46 +130,35 @@ func (a *WebTransactionTestsAPIService) CreateWebTransactionsTestExecute(r ApiCr
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -270,41 +259,31 @@ func (a *WebTransactionTestsAPIService) DeleteWebTransactionsTestExecute(r ApiDe
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarHTTPResponse, newErr
+		return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	return localVarHTTPResponse, nil
@@ -418,41 +397,31 @@ func (a *WebTransactionTestsAPIService) GetWebTransactionsTestExecute(r ApiGetWe
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -555,41 +524,31 @@ func (a *WebTransactionTestsAPIService) GetWebTransactionsTestsExecute(r ApiGetW
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -714,46 +673,35 @@ func (a *WebTransactionTestsAPIService) UpdateWebTransactionsTestExecute(r ApiUp
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 502 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -766,14 +714,4 @@ func (a *WebTransactionTestsAPIService) UpdateWebTransactionsTestExecute(r ApiUp
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *WebTransactionTestsAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/usage/api_quotas.go
+++ b/usage/api_quotas.go
@@ -106,41 +106,31 @@ func (a *QuotasAPIService) AssignOrganizationsAccountGroupsQuotasExecute(r ApiAs
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -238,41 +228,31 @@ func (a *QuotasAPIService) AssignOrganizationsQuotasExecute(r ApiAssignOrganizat
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -362,41 +342,31 @@ func (a *QuotasAPIService) GetQuotasExecute(r ApiGetQuotasRequest) (*Quotas, *ht
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -492,41 +462,31 @@ func (a *QuotasAPIService) UnassignOrganizationsAccountGroupsQuotasExecute(r Api
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarHTTPResponse, newErr
+		return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	return localVarHTTPResponse, nil
@@ -613,52 +573,32 @@ func (a *QuotasAPIService) UnassignOrganizationsQuotasExecute(r ApiUnassignOrgan
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarHTTPResponse, newErr
+			return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarHTTPResponse, newErr
+		return localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	return localVarHTTPResponse, nil
-}
-
-func (a *QuotasAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }

--- a/usage/api_usage.go
+++ b/usage/api_usage.go
@@ -130,41 +130,31 @@ func (a *UsageAPIService) GetEnterpriseAgentsUnitsUsageExecute(r ApiGetEnterpris
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -295,41 +285,31 @@ func (a *UsageAPIService) GetTestsUnitsUsageExecute(r ApiGetTestsUnitsUsageReque
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -440,41 +420,31 @@ func (a *UsageAPIService) GetUsageExecute(r ApiGetUsageRequest) (*Usage, *http.R
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-		newErr := &internalerror.GenericAPIError{
-			Body:  localVarBody,
-			ErrorMessage: localVarHTTPResponse.Status,
-		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v ValidationError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v UnauthorizedError
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
-            a.decodeError(&v, localVarBody, localVarHTTPResponse, newErr)
-            return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, &v, localVarBody, localVarHTTPResponse)
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, localVarHTTPResponse, internalerror.DecodeError(a.Client.Decode, nil, localVarBody, localVarHTTPResponse)
 	}
 
 	err = a.Client.Decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -487,14 +457,4 @@ func (a *UsageAPIService) GetUsageExecute(r ApiGetUsageRequest) (*Usage, *http.R
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
-}
-
-func (a *UsageAPIService) decodeError(v interface{}, localVarBody []byte, localVarHTTPResponse *http.Response, newErr *internalerror.GenericAPIError) {
-    err := a.Client.Decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-        newErr.ErrorMessage = err.Error()
-        return
-    }
-    newErr.ErrorMessage = internalerror.FormatErrorMessage(localVarHTTPResponse.Status, string(localVarBody), &v)
-    newErr.Model = v
 }


### PR DESCRIPTION
- **feature: wipes existing code in preparation for new version**
- **feat: Fixes the client content type matching regex**
- **[GitHub Bot] Generated go SDK (#125)**
- **fix: fixes content-type regex matcher (#126)**
- **[GitHub Bot] Generated go SDK (#128)**
- **feature: Support new release workflow and set User-Agent header with SDK version (#131)**
- **[GitHub Bot] Generated go SDK (#133)**
- **[GitHub Bot] Generated go SDK (#134)**
- **[GitHub Bot] Generated go SDK (#135)**
- **[GitHub Bot] Generated go SDK (#137)**
- **feat: Print the response log when the api call failed (#139)**
- **[GitHub Bot] Generated go SDK (#142)**
- **[GitHub Bot] Generated go SDK (#143)**
- **[GitHub Bot] Generated go SDK (#144)**
- **[GitHub Bot] Generated go SDK (#146)**
- **[GitHub Bot] Generated go SDK (#147)**
- **[GitHub Bot] Generated go SDK (#149)**
- **[GitHub Bot] Generated go SDK (#150)**
- **feat: Use retry http and add backoff (#151)**
- **[GitHub Bot] Generated go SDK (#153)**
- **[GitHub Bot] Generated go SDK (#158)**
- **[GitHub Bot] Generated go SDK (#173)**
- **Update CODEOWNERS**
- **[GitHub Bot] Generated go SDK (#178)**
- **feat: handle unknown enum values in generated go sdk (#181)**
- **[GitHub Bot] Generated go SDK (#185)**
- **[GitHub Bot] Generated go SDK (#186)**
- **[GitHub Bot] Generated go SDK (#187)**
- **[GitHub Bot] Generated go SDK (#188)**
- **[GitHub Bot] Generated go SDK (#194)**
- **fix: qualify nullable bool constructors (#197)**
- **[GitHub Bot] Generated go SDK (#196)**
- **[GitHub Bot] Generated go SDK (#200)**
- **fix(error): centralize API error decoding (#203)**
- **[GitHub Bot] Generated go SDK**
