### PR TITLE
fix(client): redact sensitive request logs

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -68,7 +68,7 @@ func (c *APIClient) GetConfig() *Configuration {
 // CallAPI do the request.
 func (c *APIClient) CallAPI(request *http.Request) (*http.Response, error) {
 	if c.cfg.Debug {
-		dump, err := httputil.DumpRequestOut(request, true)
+		dump, err := dumpRedactedRequest(request)
 		if err != nil {
 			return nil, err
 		}
@@ -86,6 +86,16 @@ func (c *APIClient) CallAPI(request *http.Request) (*http.Response, error) {
 	}
 
 	return resp, err
+}
+
+func dumpRedactedRequest(request *http.Request) ([]byte, error) {
+	requestForLogging := request.Clone(request.Context())
+	if requestForLogging.Header.Get("Authorization") != "" {
+		requestForLogging.Header.Set("Authorization", "[REDACTED]")
+	}
+
+	// Request bodies can contain passwords, API keys, and other secrets.
+	return httputil.DumpRequestOut(requestForLogging, false)
 }
 
 // PrepareRequest build the request

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -18,6 +18,45 @@ func newRequestTestClient(cfg *Configuration) *APIClient {
 	return &APIClient{cfg: cfg}
 }
 
+func TestDumpRedactedRequest(t *testing.T) {
+	const requestBody = `{"password":"body-password"}`
+	request, err := http.NewRequest(
+		http.MethodPost,
+		"https://example.test/resource",
+		strings.NewReader(requestBody),
+	)
+	if err != nil {
+		t.Fatalf("creating request: %v", err)
+	}
+	request.Header.Set("Authorization", "Bearer header-token")
+
+	dump, err := dumpRedactedRequest(request)
+	if err != nil {
+		t.Fatalf("dumpRedactedRequest() error = %v", err)
+	}
+	logged := string(dump)
+
+	for _, secret := range []string{"body-password", "header-token"} {
+		if strings.Contains(logged, secret) {
+			t.Errorf("debug request log contains sensitive value %q", secret)
+		}
+	}
+	if !strings.Contains(logged, "Authorization: [REDACTED]") {
+		t.Errorf("debug request log does not contain a redacted Authorization header\nlog:\n%s", logged)
+	}
+
+	if got := request.Header.Get("Authorization"); got != "Bearer header-token" {
+		t.Errorf("original Authorization header = %q, want unchanged", got)
+	}
+	body, err := io.ReadAll(request.Body)
+	if err != nil {
+		t.Fatalf("reading original request body: %v", err)
+	}
+	if got := string(body); got != requestBody {
+		t.Errorf("original request body = %q, want %q", got, requestBody)
+	}
+}
+
 func TestPrepareRequestHeadersQueryAndContext(t *testing.T) {
 	baseCtx, cancel := context.WithCancel(context.Background())
 	ctx := context.WithValue(baseCtx, contextKey{}, "context-value")


### PR DESCRIPTION
## Summary

- Omit request bodies from SDK debug logs.
- Redact the `Authorization` header before logging requests.
- Leave response logging unchanged for Terraform troubleshooting.

## Why

CodeQL found that generated password and API-key fields could flow into request logs.

## Validation

- `go test -race ./client`
- `go test ./...`
- `go vet ./...`
- `git diff --check`
