### PR TITLE
fix(client): limit debug request logging

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -68,11 +68,7 @@ func (c *APIClient) GetConfig() *Configuration {
 // CallAPI do the request.
 func (c *APIClient) CallAPI(request *http.Request) (*http.Response, error) {
 	if c.cfg.Debug {
-		dump, err := dumpRedactedRequest(request)
-		if err != nil {
-			return nil, err
-		}
-		log.Printf("\n%s\n", string(dump))
+		log.Printf("\n%s\n", formatRequestLog(request))
 	}
 
 	resp, err := c.cfg.HTTPClient.Do(request)
@@ -88,14 +84,23 @@ func (c *APIClient) CallAPI(request *http.Request) (*http.Response, error) {
 	return resp, err
 }
 
-func dumpRedactedRequest(request *http.Request) ([]byte, error) {
-	requestForLogging := request.Clone(request.Context())
-	if requestForLogging.Header.Get("Authorization") != "" {
-		requestForLogging.Header.Set("Authorization", "[REDACTED]")
-	}
+func formatRequestLog(request *http.Request) string {
+	const detailsOmitted = " request (URL, headers, and body omitted)"
 
-	// Request bodies can contain passwords, API keys, and other secrets.
-	return httputil.DumpRequestOut(requestForLogging, false)
+	switch request.Method {
+	case http.MethodDelete:
+		return "DELETE" + detailsOmitted
+	case http.MethodGet:
+		return "GET" + detailsOmitted
+	case http.MethodPatch:
+		return "PATCH" + detailsOmitted
+	case http.MethodPost:
+		return "POST" + detailsOmitted
+	case http.MethodPut:
+		return "PUT" + detailsOmitted
+	default:
+		return "HTTP" + detailsOmitted
+	}
 }
 
 // PrepareRequest build the request

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -18,42 +18,41 @@ func newRequestTestClient(cfg *Configuration) *APIClient {
 	return &APIClient{cfg: cfg}
 }
 
-func TestDumpRedactedRequest(t *testing.T) {
+func TestFormatRequestLog(t *testing.T) {
 	const requestBody = `{"password":"body-password"}`
 	request, err := http.NewRequest(
 		http.MethodPost,
-		"https://example.test/resource",
+		"https://example.test/resource/path-secret?apiKey=query-secret",
 		strings.NewReader(requestBody),
 	)
 	if err != nil {
 		t.Fatalf("creating request: %v", err)
 	}
 	request.Header.Set("Authorization", "Bearer header-token")
+	request.Header.Set("Cookie", "session=cookie-secret")
+	request.Header.Set("X-Api-Key", "custom-header-secret")
 
-	dump, err := dumpRedactedRequest(request)
-	if err != nil {
-		t.Fatalf("dumpRedactedRequest() error = %v", err)
-	}
-	logged := string(dump)
+	logged := formatRequestLog(request)
 
-	for _, secret := range []string{"body-password", "header-token"} {
+	for _, secret := range []string{
+		"body-password",
+		"path-secret",
+		"query-secret",
+		"header-token",
+		"cookie-secret",
+		"custom-header-secret",
+	} {
 		if strings.Contains(logged, secret) {
 			t.Errorf("debug request log contains sensitive value %q", secret)
 		}
 	}
-	if !strings.Contains(logged, "Authorization: [REDACTED]") {
-		t.Errorf("debug request log does not contain a redacted Authorization header\nlog:\n%s", logged)
+	if want := "POST request (URL, headers, and body omitted)"; logged != want {
+		t.Errorf("formatRequestLog() = %q, want %q", logged, want)
 	}
 
-	if got := request.Header.Get("Authorization"); got != "Bearer header-token" {
-		t.Errorf("original Authorization header = %q, want unchanged", got)
-	}
-	body, err := io.ReadAll(request.Body)
-	if err != nil {
-		t.Fatalf("reading original request body: %v", err)
-	}
-	if got := string(body); got != requestBody {
-		t.Errorf("original request body = %q, want %q", got, requestBody)
+	request.Method = "method-secret"
+	if got, want := formatRequestLog(request), "HTTP request (URL, headers, and body omitted)"; got != want {
+		t.Errorf("formatRequestLog() with unknown method = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

- log only a normalized HTTP method when debug mode is enabled
- omit URL paths, query parameters, request headers, and request bodies
- cover secrets in every omitted request component and unknown methods

## Why

The cutover CodeQL scan still reports `go/clear-text-logging` because the raw request dump receives
data derived from sensitive generated model fields. Redacting Authorization and omitting the body
does not remove sensitive paths, query parameters, or other headers from the debug output.

Debug request output is now limited to a line such as
`POST request (URL, headers, and body omitted)`. Response debug logging is unchanged.

## Validation

- `go test ./...`
- `go vet ./...`
