### PR TITLE
docs: add project governance files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+*<oss-conduct@cisco.com>*.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available
+at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# Contributing to the ThousandEyes Go SDK
+
+Thank you for considering a contribution to the ThousandEyes Go SDK.
+
+## Generated code
+
+The API domain packages in this repository are generated from ThousandEyes
+OpenAPI definitions. Generated files contain a `Code generated` notice.
+
+Do not edit generated files as a one-off fix. Changes to generated APIs must be
+made in the appropriate specification or generator source and then regenerated
+so they remain reproducible. Pull requests that include generated output should
+describe its source and the command or workflow used to produce it.
+
+Contributions to shared runtime code, documentation, tests, and workflows are
+welcome.
+
+## Development setup
+
+Install the Go version declared in `go.mod`, clone your fork, and download the
+module dependencies:
+
+```sh
+go mod download
+```
+
+Tests must not require real ThousandEyes credentials or external network
+access.
+
+## Development workflow
+
+1. Fork the repository.
+2. Create a focused feature branch.
+3. Make the change and add or update tests where applicable.
+4. Format and validate the repository:
+
+   ```sh
+   gofmt -w path/to/changed_file.go
+   go test -race ./...
+   git diff --check
+   ```
+
+5. Push the branch and open a pull request.
+
+Keep pull requests focused and explain what changed, why it is needed, and how
+it was validated. Use concise, imperative commit subjects.
+
+## Reporting bugs and suggesting features
+
+For bugs, feature requests, or questions about the SDK, contact
+[ThousandEyes Support](https://docs.thousandeyes.com/product-documentation/getting-started/getting-support-from-thousandeyes#contacting-support).
+
+Do not report security vulnerabilities through a public GitHub issue. Follow
+the private process in [SECURITY.md](./SECURITY.md).
+
+All contributors must follow the [Code of Conduct](./CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -218,6 +218,11 @@ one-off fix. Changes to generated APIs must be made in the appropriate
 specification or generator source and then regenerated. Contributions to shared
 runtime code, documentation, tests, and workflows are welcome.
 
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for local development, formatting,
+testing, and pull request guidance. Report security vulnerabilities privately
+as described in [SECURITY.md](./SECURITY.md). All contributors must follow the
+[Code of Conduct](./CODE_OF_CONDUCT.md).
+
 ## License
 
 This project is licensed under the [Apache License 2.0](./LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policies and Procedures
+
+This document outlines security procedures and general policies for the
+`thousandeyes-sdk-go` project.
+
+- [Reporting a Bug](#reporting-a-bug)
+- [Disclosure Policy](#disclosure-policy)
+- [Comments on this Policy](#comments-on-this-policy)
+
+## Reporting a Bug
+
+The Cisco ThousandEyes team and community take all security bugs in
+`thousandeyes-sdk-go` seriously. Thank you for improving the security of
+`thousandeyes-sdk-go`. We appreciate your efforts and responsible disclosure and
+will make every effort to acknowledge your contributions.
+
+Report security bugs by emailing `oss-security@cisco.com`.
+
+The lead maintainer will acknowledge your email within 48 hours, and will send a
+more detailed response within 48 hours indicating the next steps in handling
+your report. After the initial reply to your report, the security team will
+endeavor to keep you informed of the progress towards a fix and full
+announcement, and may ask for additional information or guidance.
+
+## Disclosure Policy
+
+When the security team receives a security bug report, they will assign it to a
+primary handler. This person will coordinate the fix and release process,
+involving the following steps:
+
+- Confirm the problem and determine the affected versions.
+- Audit code to find any potential similar problems.
+- Prepare fixes for all releases still under maintenance. These fixes will be
+  released as quickly as possible.
+
+## Comments on this Policy
+
+If you have suggestions on how this process could be improved please submit a
+pull request.


### PR DESCRIPTION
## Summary

- add a Go-specific contribution and development workflow
- add the security policy and code of conduct used by the public ThousandEyes SDKs
- link the new governance documents from the root README

## Why

This makes contribution, security reporting, and community expectations explicit
and aligns the Go SDK with the public Java and Python SDK repositories.

## Validation

- `git diff --check origin/main...HEAD`
- verified the diff contains no internal issue identifiers or internal-only links
- independently reviewed for consistency with the Java and Python SDK policies

Documentation only; no SDK runtime or generated code changed.
