### PR TITLE
fix: Restore opt-in debug request logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,11 @@ different API v7 endpoint, while fields on the configuration allow a custom
 HTTP client, context, and user agent. Create and reuse a configured API client;
 do not modify its configuration while requests are in flight.
 
-Keep `Debug` disabled in production. Debug mode dumps complete HTTP requests
-and responses, which can include the bearer token and sensitive API data.
+`Debug` is disabled by default and should remain disabled in production. When
+enabled, it dumps complete HTTP requests and responses, including payloads.
+Common credential fields and authentication or cookie headers are redacted, but
+URLs, other headers, and payloads can still contain sensitive API data. Treat
+debug logs as sensitive and review them before persisting or sharing them.
 
 Account-group context is optional and is set per request with `.Aid(aid)` on
 operations that support it. The example reads it from `TE_AID` when present.

--- a/client/client.go
+++ b/client/client.go
@@ -18,10 +18,18 @@ import (
 	"github.com/hashicorp/go-retryablehttp"
 )
 
+const sensitiveFieldPattern = `(?:password|secret(?:[_-]?key)?|api[_-]?key|` +
+	`(?:access|refresh|bearer|auth|account|api)?[_-]?token|` +
+	`(?:oauth[_-]?)?client[_-]?secret|authorization)`
+
 var (
 	JsonCheck       = regexp.MustCompile(`(?i:application/((hal|problem)\+)?json)`)
 	queryParamSplit = regexp.MustCompile(`(^|&)([^&]+)`)
 	queryDescape    = strings.NewReplacer("%5B", "[", "%5D", "]")
+
+	sensitiveJSONFieldRe  = regexp.MustCompile(`(?i)("` + sensitiveFieldPattern + `"\s*:\s*")((?:\\.|[^"\\])*)(")`)
+	sensitiveParameterRe  = regexp.MustCompile(`(?im)((?:^|[?&])` + sensitiveFieldPattern + `=)[^&\s\r\n]*`)
+	sensitiveHeaderLineRe = regexp.MustCompile(`(?im)^((?:Authorization|Proxy-Authorization|Cookie|Set-Cookie|X-Api-Key|Api-Key|X-Auth-Token)\s*:\s*)[^\r\n]*`)
 )
 
 // APIClient In most cases there should be only one, shared, APIClient.
@@ -68,39 +76,61 @@ func (c *APIClient) GetConfig() *Configuration {
 // CallAPI do the request.
 func (c *APIClient) CallAPI(request *http.Request) (*http.Response, error) {
 	if c.cfg.Debug {
-		log.Printf("\n%s\n", formatRequestLog(request))
+		dump, err := dumpRedactedRequest(request)
+		if err != nil {
+			return nil, err
+		}
+		log.Printf("\n%s\n", string(dump))
 	}
 
 	resp, err := c.cfg.HTTPClient.Do(request)
 
-	if c.cfg.Debug {
+	if c.cfg.Debug && resp != nil {
 		dump, err := httputil.DumpResponse(resp, true)
 		if err != nil {
 			return resp, err
 		}
-		log.Printf("\n%s\n", string(dump))
+		log.Printf("\n%s\n", string(redactSensitiveData(dump)))
 	}
 
 	return resp, err
 }
 
-func formatRequestLog(request *http.Request) string {
-	const detailsOmitted = " request (URL, headers, and body omitted)"
+func redactSensitiveData(dump []byte) []byte {
+	dump = sensitiveHeaderLineRe.ReplaceAll(dump, []byte(`${1}[REDACTED]`))
+	dump = sensitiveParameterRe.ReplaceAll(dump, []byte(`${1}[REDACTED]`))
+	return sensitiveJSONFieldRe.ReplaceAll(dump, []byte(`${1}[REDACTED]${3}`))
+}
 
-	switch request.Method {
-	case http.MethodDelete:
-		return "DELETE" + detailsOmitted
-	case http.MethodGet:
-		return "GET" + detailsOmitted
-	case http.MethodPatch:
-		return "PATCH" + detailsOmitted
-	case http.MethodPost:
-		return "POST" + detailsOmitted
-	case http.MethodPut:
-		return "PUT" + detailsOmitted
-	default:
-		return "HTTP" + detailsOmitted
+func dumpRedactedRequest(request *http.Request) ([]byte, error) {
+	requestForLogging := request.Clone(request.Context())
+	if requestForLogging.Header.Get("Authorization") != "" {
+		requestForLogging.Header.Set("Authorization", "[REDACTED]")
 	}
+
+	if request.Body != nil {
+		if request.GetBody != nil {
+			body, err := request.GetBody()
+			if err != nil {
+				return nil, err
+			}
+			requestForLogging.Body = body
+		} else {
+			body, err := io.ReadAll(request.Body)
+			if err != nil {
+				return nil, err
+			}
+			_ = request.Body.Close()
+			request.Body = io.NopCloser(bytes.NewReader(body))
+			requestForLogging.Body = io.NopCloser(bytes.NewReader(body))
+		}
+	}
+
+	dump, err := httputil.DumpRequestOut(requestForLogging, true)
+	if err != nil {
+		return nil, err
+	}
+	return redactSensitiveData(dump), nil
 }
 
 // PrepareRequest build the request

--- a/client/client.go
+++ b/client/client.go
@@ -78,9 +78,10 @@ func (c *APIClient) CallAPI(request *http.Request) (*http.Response, error) {
 	if c.cfg.Debug {
 		dump, err := dumpRedactedRequest(request)
 		if err != nil {
-			return nil, err
+			log.Printf("failed to dump request for debug logging: %v", err)
+		} else {
+			log.Printf("\n%s\n", string(dump))
 		}
-		log.Printf("\n%s\n", string(dump))
 	}
 
 	resp, err := c.cfg.HTTPClient.Do(request)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -18,11 +18,12 @@ func newRequestTestClient(cfg *Configuration) *APIClient {
 	return &APIClient{cfg: cfg}
 }
 
-func TestFormatRequestLog(t *testing.T) {
-	const requestBody = `{"password":"body-password"}`
+func TestDumpRedactedRequest(t *testing.T) {
+	const requestBody = `{"password":"alpha beta","apiKey":"gamma&delta",` +
+		`"token":"epsilon\"zeta","clientSecret":"eta,theta","name":"body-visible"}`
 	request, err := http.NewRequest(
 		http.MethodPost,
-		"https://example.test/resource/path-secret?apiKey=query-secret",
+		"https://example.test/resource/path-visible?apiKey=query-secret&filter=query-visible",
 		strings.NewReader(requestBody),
 	)
 	if err != nil {
@@ -31,28 +32,76 @@ func TestFormatRequestLog(t *testing.T) {
 	request.Header.Set("Authorization", "Bearer header-token")
 	request.Header.Set("Cookie", "session=cookie-secret")
 	request.Header.Set("X-Api-Key", "custom-header-secret")
+	request.Header.Set("X-Trace", "header-visible")
 
-	logged := formatRequestLog(request)
+	dump, err := dumpRedactedRequest(request)
+	if err != nil {
+		t.Fatalf("dumpRedactedRequest() error = %v", err)
+	}
+	logged := string(dump)
 
 	for _, secret := range []string{
-		"body-password",
-		"path-secret",
-		"query-secret",
 		"header-token",
 		"cookie-secret",
 		"custom-header-secret",
+		"query-secret",
+		"alpha",
+		"beta",
+		"gamma",
+		"delta",
+		"epsilon",
+		"zeta",
+		"eta",
+		"theta",
 	} {
 		if strings.Contains(logged, secret) {
 			t.Errorf("debug request log contains sensitive value %q", secret)
 		}
 	}
-	if want := "POST request (URL, headers, and body omitted)"; logged != want {
-		t.Errorf("formatRequestLog() = %q, want %q", logged, want)
+	for _, detail := range []string{"path-visible", "query-visible", "header-visible", "body-visible"} {
+		if !strings.Contains(logged, detail) {
+			t.Errorf("debug request log does not contain request detail %q", detail)
+		}
+	}
+	if !strings.Contains(logged, "Authorization: [REDACTED]") {
+		t.Errorf("debug request log does not contain a redacted Authorization header\nlog:\n%s", logged)
 	}
 
-	request.Method = "method-secret"
-	if got, want := formatRequestLog(request), "HTTP request (URL, headers, and body omitted)"; got != want {
-		t.Errorf("formatRequestLog() with unknown method = %q, want %q", got, want)
+	if got := request.Header.Get("Authorization"); got != "Bearer header-token" {
+		t.Errorf("original Authorization header = %q, want unchanged", got)
+	}
+	if got := request.Header.Get("Cookie"); got != "session=cookie-secret" {
+		t.Errorf("original Cookie header = %q, want unchanged", got)
+	}
+	if got := request.Header.Get("X-Api-Key"); got != "custom-header-secret" {
+		t.Errorf("original X-Api-Key header = %q, want unchanged", got)
+	}
+	body, err := io.ReadAll(request.Body)
+	if err != nil {
+		t.Fatalf("reading original request body: %v", err)
+	}
+	if got := string(body); got != requestBody {
+		t.Errorf("original request body = %q, want %q", got, requestBody)
+	}
+}
+
+func TestRedactSensitiveResponseData(t *testing.T) {
+	dump := []byte("HTTP/1.1 200 OK\r\n" +
+		"Set-Cookie: session=response-cookie\r\n" +
+		"X-Trace: response-header\r\n" +
+		"Content-Type: application/json\r\n\r\n" +
+		`{"refreshToken":"response token","result":"response-visible"}`)
+
+	logged := string(redactSensitiveData(dump))
+	for _, secret := range []string{"response-cookie", "response token"} {
+		if strings.Contains(logged, secret) {
+			t.Errorf("debug response log contains sensitive value %q", secret)
+		}
+	}
+	for _, detail := range []string{"response-header", "response-visible"} {
+		if !strings.Contains(logged, detail) {
+			t.Errorf("debug response log does not contain response detail %q", detail)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- restore complete request and response dumps when `Debug` is enabled
- redact common credential fields and authentication or cookie headers
- preserve non-sensitive URL, header, and payload details for troubleshooting
- preserve the outbound request body and document that debug logs remain sensitive

## Why

The Terraform provider uses opt-in SDK debug output to compare generated API requests with Terraform configuration during troubleshooting. #220 removed the URL, headers, and payload needed for that investigation.

This restores that visibility without enabling debug logging by default or exposing common credentials.

## Validation

- `go test -count=1 -race ./...`
- `go vet ./...`
- `git diff --check`

Refs CP-2706