### PR TITLE
chore(release): prepare v3.0.0

### DIFF
--- a/client/configuration.go
+++ b/client/configuration.go
@@ -8,7 +8,7 @@ import (
 
 // This sdkVersion will be updated by release.yaml
 // Do not modify this line manually
-var sdkVersion = "v3"
+var sdkVersion = "v3.0.0"
 
 func SDKVersion() string {
 	return sdkVersion


### PR DESCRIPTION
## Summary

- set the embedded SDK version to `v3.0.0`
- keep the Go module path unchanged at `github.com/thousandeyes/thousandeyes-sdk-go/v3`

## Why

Prepare the GA release so the SDK User-Agent reports the exact published version.

## Validation

- `go test ./client -count=1`
- `go test -race -coverprofile=coverage.txt -covermode=atomic ./...`

After this merges, the `v3.0.0` tag and GitHub Release can target the resulting `main` commit.
